### PR TITLE
Feature/add verifications

### DIFF
--- a/lib/bespiral/commune/commune.ex
+++ b/lib/bespiral/commune/commune.ex
@@ -32,7 +32,9 @@ defmodule BeSpiral.Commune do
 
         {:validator, account}, query ->
           query
-          |> join(:inner, [a], v in Validator, on: a.id == v.action_id and v.validator_id == ^account)
+          |> join(:inner, [a], v in Validator,
+            on: a.id == v.action_id and v.validator_id == ^account
+          )
 
         {:is_completed, is_completed}, query ->
           query
@@ -451,13 +453,13 @@ defmodule BeSpiral.Commune do
 
     response = Ecto.Adapters.SQL.query!(Repo, query, [account])
 
-    columns = Enum.map(response.columns, &(String.to_atom(&1)))
+    columns = Enum.map(response.columns, &String.to_atom(&1))
 
     result =
-      Enum.map(response.rows, fn(row) ->
+      Enum.map(response.rows, fn row ->
         Enum.into(Enum.zip(columns, row), %{})
       end)
-      |> Enum.map(fn(row) ->
+      |> Enum.map(fn row ->
         %{row | created_at: DateTime.from_naive!(row.created_at, "Etc/UTC")}
       end)
 
@@ -503,10 +505,10 @@ defmodule BeSpiral.Commune do
 
     response = Ecto.Adapters.SQL.query!(Repo, query, [id, account])
 
-    columns = Enum.map(response.columns, &(String.to_atom(&1)))
+    columns = Enum.map(response.columns, &String.to_atom(&1))
 
     results =
-      Enum.map(response.rows, fn(row) ->
+      Enum.map(response.rows, fn row ->
         Enum.into(Enum.zip(columns, row), %{})
       end)
 

--- a/lib/bespiral/commune/commune.ex
+++ b/lib/bespiral/commune/commune.ex
@@ -457,9 +457,7 @@ defmodule BeSpiral.Commune do
       Enum.map(response.rows, fn(row) ->
         Enum.into(Enum.zip(columns, row), %{})
       end)
-
-    result =
-      Enum.map(result, fn(row) ->
+      |> Enum.map(fn(row) ->
         %{row | created_at: DateTime.from_naive!(row.created_at, "Etc/UTC")}
       end)
 
@@ -507,13 +505,18 @@ defmodule BeSpiral.Commune do
 
     columns = Enum.map(response.columns, &(String.to_atom(&1)))
 
-    [result | _] =
+    results =
       Enum.map(response.rows, fn(row) ->
         Enum.into(Enum.zip(columns, row), %{})
       end)
 
-    result = %{result | created_at: DateTime.from_naive!(result.created_at, "Etc/UTC")}
+    case results do
+      [result | _] ->
+        result = %{result | created_at: DateTime.from_naive!(result.created_at, "Etc/UTC")}
+        {:ok, result}
 
-    {:ok, result}
+      [] ->
+        {:ok, nil}
+    end
   end
 end

--- a/lib/bespiral_web/resolvers/commune.ex
+++ b/lib/bespiral_web/resolvers/commune.ex
@@ -88,4 +88,12 @@ defmodule BeSpiralWeb.Resolvers.Commune do
   def get_members_count(%Community{} = community, _, _) do
     Commune.get_members_count(community)
   end
+
+  def get_verifications_history(_, %{input: input}, _) do
+    Commune.get_verifications_history(input)
+  end
+
+  def get_verification(_, %{input: input}, _) do
+    Commune.get_verification(input)
+  end
 end

--- a/lib/bespiral_web/schema/commmune_types.ex
+++ b/lib/bespiral_web/schema/commmune_types.ex
@@ -8,15 +8,15 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
   import Absinthe.Resolution.Helpers, only: [dataloader: 1]
   alias BeSpiralWeb.Resolvers.Commune
 
-  @desc "Community Queries on BeSpiral"
+  @desc "Community Queries"
   object :community_queries do
-    @desc "A list of sales in BeSpiral"
+    @desc "A list of sales"
     field :sales, non_null(list_of(non_null(:sale))) do
       arg(:input, non_null(:sales_input))
       resolve(&Commune.get_sales/3)
     end
 
-    @desc "A list of communities in BeSpiral"
+    @desc "A list of communities"
     field :communities, non_null(list_of(non_null(:community))) do
       resolve(&Commune.get_communities/3)
     end
@@ -27,19 +27,31 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
       resolve(&Commune.find_community/3)
     end
 
+    @desc "A list of verifications"
+    field :verifications, non_null(list_of(:verification_history)) do
+      arg(:input, non_null(:verifications_input))
+      resolve(&Commune.get_verifications_history/3)
+    end
+
+    @desc "A single verification"
+    field :verification, :verification do
+      arg(:input, non_null(:verification_input))
+      resolve(&Commune.get_verification/3)
+    end
+
     @desc "A list of sale history"
     field :sale_history, list_of(:sale_history) do
       resolve(&Commune.get_sales_history/3)
     end
 
-    @desc "A single sale from BeSpiral"
+    @desc "A single sale"
     field :sale, :sale do
       arg(:input, non_null(:sale_input))
       resolve(&Commune.get_sale/3)
     end
   end
 
-  @desc "Community Subscriptions on BeSpiral"
+  @desc "Community Subscriptions"
   object :community_subscriptions do
     @desc "A subscription to resolve operations on the sales table"
     field :sales_operation, :sale do
@@ -99,7 +111,18 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:validator, :string)
   end
 
-  @desc "A community on BeSpiral"
+  @desc "Input to collect verifications"
+  input_object :verifications_input do
+    field(:validator, non_null(:string))
+  end
+
+  @desc "Input to collect verification"
+  input_object :verification_input do
+    field(:id, non_null(:integer))
+    field(:validator, non_null(:string))
+  end
+
+  @desc "A community"
   object :community do
     field(:symbol, non_null(:string))
     field(:creator, non_null(:string))
@@ -202,7 +225,7 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:created_at, non_null(:datetime))
   end
 
-  @desc "A network in BeSpiral"
+  @desc "A network"
   object :network do
     field(:created_block, non_null(:integer))
     field(:created_tx, non_null(:string))
@@ -213,7 +236,7 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:invited_by, :string)
   end
 
-  @desc "A sale on BeSpiral"
+  @desc "A sale"
   object :sale do
     field(:id, non_null(:integer))
     field(:creator_id, non_null(:string))
@@ -250,7 +273,7 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:units, :integer)
   end
 
-  @desc "A transfer on BeSpiral"
+  @desc "A transfer"
   object :transfer do
     field(:from_id, non_null(:string))
     field(:to_id, non_null(:string))
@@ -274,9 +297,50 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:created_at, non_null(:datetime))
   end
 
+  @desc "A minimal verification used to on a historical list"
+  object :verification_history do
+    field(:objective_id, non_null(:integer))
+    field(:action_id, non_null(:integer))
+    field(:claim_id, non_null(:integer))
+    field(:logo, non_null(:string))
+    field(:description, non_null(:string))
+    field(:created_at, non_null(:datetime))
+    field(:status, non_null(:verification_history_status_type))
+  end
+
+  @desc "A claimed action verification"
+  object :verification do
+    field(:symbol, non_null(:string))
+    field(:logo, non_null(:string))
+    field(:name, non_null(:string))
+    field(:objective_description, non_null(:string))
+    field(:action_description, non_null(:string))
+    field(:claimer_reward, non_null(:float))
+    field(:verifier_reward, non_null(:float))
+    field(:claimer, non_null(:string))
+    field(:created_at, non_null(:datetime))
+    field(:status, non_null(:verification_status_type))
+  end
+
   @desc "Action verification types"
   enum :verification_type do
     value(:automatic, as: "automatic", description: "An action that is verified automatically")
     value(:claimable, as: "claimable", description: "An action that needs be mannually verified")
+  end
+
+  @desc "Verification history status type"
+  enum :verification_history_status_type do
+    value(:pending, as: "pending", description: "A verification that is pending")
+    value(:disapproval, as: "disapproval", description: "A verification that was disapproved")
+    value(:approval, as: "approval", description: "A verification that was approved")
+  end
+
+  @desc "Verification status type"
+  enum :verification_status_type do
+    value(:pending, as: "pending", description: "A verification that is pending")
+    value(:disapproved_and_under_review, as: "disapproved_and_under_review", description: "A verification that was disapproved but still is under review")
+    value(:approved_and_under_review, as: "approved_and_under_review", description: "A verification that was approved but still is under review")
+    value(:disapproved, as: "disapproved", description: "A verification that was disapproved and finished")
+    value(:approved, as: "approved", description: "A verification that was approved and finished")
   end
 end

--- a/lib/bespiral_web/schema/commmune_types.ex
+++ b/lib/bespiral_web/schema/commmune_types.ex
@@ -208,6 +208,7 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
       arg(:input, :checks_input)
       resolve(dataloader(BeSpiral.Commune))
     end
+
     field(:created_block, non_null(:integer))
     field(:created_tx, non_null(:string))
     field(:created_eos_account, non_null(:string))
@@ -338,9 +339,22 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
   @desc "Verification status type"
   enum :verification_status_type do
     value(:pending, as: "pending", description: "A verification that is pending")
-    value(:disapproved_and_under_review, as: "disapproved_and_under_review", description: "A verification that was disapproved but still is under review")
-    value(:approved_and_under_review, as: "approved_and_under_review", description: "A verification that was approved but still is under review")
-    value(:disapproved, as: "disapproved", description: "A verification that was disapproved and finished")
+
+    value(:disapproved_and_under_review,
+      as: "disapproved_and_under_review",
+      description: "A verification that was disapproved but still is under review"
+    )
+
+    value(:approved_and_under_review,
+      as: "approved_and_under_review",
+      description: "A verification that was approved but still is under review"
+    )
+
+    value(:disapproved,
+      as: "disapproved",
+      description: "A verification that was disapproved and finished"
+    )
+
     value(:approved, as: "approved", description: "A verification that was approved and finished")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BeSpiral.Mixfile do
   def project do
     [
       app: :bespiral,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/bespiral_web/resolvers/commune_test.exs
+++ b/test/bespiral_web/resolvers/commune_test.exs
@@ -119,7 +119,7 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
 
       assert 1 == Enum.count(objectives)
 
-      assert (1 + @num) ==
+      assert 1 + @num ==
                Enum.reduce(objectives, 0, fn obj, acc ->
                  Enum.count(obj["actions"]) + acc
                end)
@@ -183,7 +183,7 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
 
       assert 1 == Enum.count(objectives)
 
-      assert (1 + @num) ==
+      assert 1 + @num ==
                Enum.reduce(objectives, 0, fn obj, acc ->
                  Enum.count(obj["actions"]) + acc
                end)
@@ -232,7 +232,7 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
 
       assert 1 == Enum.count(objectives)
 
-      assert (1 + @num) ==
+      assert 1 + @num ==
                Enum.reduce(objectives, 0, fn obj, acc ->
                  Enum.count(obj["actions"]) + acc
                end)
@@ -281,7 +281,7 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
 
       assert 1 == Enum.count(objectives)
 
-      assert (1 + @num) ==
+      assert 1 + @num ==
                Enum.reduce(objectives, 0, fn obj, acc ->
                  Enum.count(obj["actions"]) + acc
                end)
@@ -330,7 +330,7 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
 
       assert 1 == Enum.count(objectives)
 
-      assert (1 + @num) ==
+      assert 1 + @num ==
                Enum.reduce(objectives, 0, fn obj, acc ->
                  Enum.count(obj["actions"]) + acc
                end)
@@ -757,19 +757,39 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
       objective = insert(:objective, %{creator: cmm_manager, community: community})
 
       # actions
-      insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "automatic"})
-      claimable_action = insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "claimable", verifications: 1})
+      insert(:action, %{
+        creator: cmm_manager,
+        objective: objective,
+        verification_type: "automatic"
+      })
+
+      claimable_action =
+        insert(:action, %{
+          creator: cmm_manager,
+          objective: objective,
+          verification_type: "claimable",
+          verifications: 1
+        })
 
       # validators
       insert(:validator, %{validator: validator1, action: claimable_action})
       insert(:validator, %{validator: validator2, action: claimable_action})
 
       # claims
-      claim_finished1 = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
-      claim_finished2 = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
-      claim_finished3 = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
-      claim_under_review1 = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: false})
-      claim_under_review2 = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: false})
+      claim_finished1 =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
+
+      claim_finished2 =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
+
+      claim_finished3 =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
+
+      claim_under_review1 =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: false})
+
+      claim_under_review2 =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: false})
 
       # checks
       insert(:check, %{claim: claim_finished1, validator: validator1, is_verified: true})
@@ -779,7 +799,6 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
       insert(:check, %{claim: claim_finished3, validator: validator2, is_verified: false})
       insert(:check, %{claim: claim_under_review1, validator: validator1, is_verified: false})
       insert(:check, %{claim: claim_under_review2, validator: validator2, is_verified: false})
-
 
       variables = %{
         "input" => %{"validator" => validator2.account}
@@ -828,15 +847,27 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
       objective = insert(:objective, %{creator: cmm_manager, community: community})
 
       # actions
-      insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "automatic"})
-      claimable_action = insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "claimable", verifications: 1})
+      insert(:action, %{
+        creator: cmm_manager,
+        objective: objective,
+        verification_type: "automatic"
+      })
+
+      claimable_action =
+        insert(:action, %{
+          creator: cmm_manager,
+          objective: objective,
+          verification_type: "claimable",
+          verifications: 1
+        })
 
       # validators
       insert(:validator, %{validator: validator1, action: claimable_action})
       insert(:validator, %{validator: validator2, action: claimable_action})
 
       # claims
-      claim_under_review = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
+      claim_under_review =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
 
       # checks
       insert(:check, %{claim: claim_under_review, validator: validator1, is_verified: false})
@@ -885,15 +916,27 @@ defmodule BeSpiralWeb.Resolvers.CommuneTest do
       objective = insert(:objective, %{creator: cmm_manager, community: community})
 
       # actions
-      insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "automatic"})
-      claimable_action = insert(:action, %{creator: cmm_manager, objective: objective, verification_type: "claimable", verifications: 1})
+      insert(:action, %{
+        creator: cmm_manager,
+        objective: objective,
+        verification_type: "automatic"
+      })
+
+      claimable_action =
+        insert(:action, %{
+          creator: cmm_manager,
+          objective: objective,
+          verification_type: "claimable",
+          verifications: 1
+        })
 
       # validators
       insert(:validator, %{validator: validator1, action: claimable_action})
       insert(:validator, %{validator: validator2, action: claimable_action})
 
       # claims
-      claim_under_review = insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
+      claim_under_review =
+        insert(:claim, %{claimer: claimer, action: claimable_action, is_verified: true})
 
       # checks
       insert(:check, %{claim: claim_under_review, validator: validator1, is_verified: true})

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -9,6 +9,8 @@ defmodule BeSpiral.Factory do
     Accounts.User,
     Commune.Action,
     Commune.AvailableSale,
+    Commune.Check,
+    Commune.Claim,
     Commune.Community,
     Commune.Network,
     Commune.Objective,
@@ -158,6 +160,30 @@ defmodule BeSpiral.Factory do
     %Validator{
       validator: build(:user),
       action: build(:action),
+      created_block: sequence(:created_block, &"#{&1}"),
+      created_tx: sequence(:tx, &"c_tx-#{&1}"),
+      created_eos_account: sequence(:created_eos_account, &"acc-eos-#{&1}"),
+      created_at: NaiveDateTime.utc_now()
+    }
+  end
+
+  def claim_factory do
+    %Claim{
+      action: build(:action),
+      claimer: build(:user),
+      is_verified: sequence(:is_completed, [true, false]),
+      created_block: sequence(:created_block, &"#{&1}"),
+      created_tx: sequence(:tx, &"c_tx-#{&1}"),
+      created_eos_account: sequence(:created_eos_account, &"acc-eos-#{&1}"),
+      created_at: NaiveDateTime.utc_now()
+    }
+  end
+
+  def check_factory do
+    %Check{
+      claim: build(:claim),
+      validator: build(:user),
+      is_verified: sequence(:is_completed, [true, false]),
       created_block: sequence(:created_block, &"#{&1}"),
       created_tx: sequence(:tx, &"c_tx-#{&1}"),
       created_eos_account: sequence(:created_eos_account, &"acc-eos-#{&1}"),


### PR DESCRIPTION
This PR add new types to retrieve verifications from the API.
Below are the changelog:
- [x] add query to get an specific verification;
- [x] add query to get all verifications from an specific validator;
- [x] add resolvers for both verification and verifications;
- [x] add types related to a verification;
- [x] add types related to a verification_history;
- [x] remove `BeSpiral` from type description;
- [x] add tests.