### PR TITLE
Feature/non null validators

### DIFF
--- a/lib/bespiral_web/schema/commmune_types.ex
+++ b/lib/bespiral_web/schema/commmune_types.ex
@@ -189,7 +189,7 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
     field(:verification_type, non_null(:verification_type))
 
     field(:objective, non_null(:objective), resolve: dataloader(BeSpiral.Commune))
-    field(:validators, list_of(non_null(:validator)), resolve: dataloader(BeSpiral.Commune))
+    field(:validators, non_null(list_of(non_null(:validator))), resolve: dataloader(BeSpiral.Commune))
     field(:claims, non_null(list_of(non_null(:claim))), resolve: dataloader(BeSpiral.Commune))
     field(:creator, non_null(:profile), resolve: dataloader(BeSpiral.Commune))
     field(:created_block, non_null(:integer))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BeSpiral.Mixfile do
   def project do
     [
       app: :bespiral,
-      version: "1.2.1",
+      version: "1.2.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Since the `dataloader` resolver always sends an empty list in case of no validators, this PR turn the validators list into a non nullable list.
