### PR TITLE
Expand sale query to allow for community details load

### DIFF
--- a/lib/bespiral_web/schema/commmune_types.ex
+++ b/lib/bespiral_web/schema/commmune_types.ex
@@ -303,7 +303,10 @@ defmodule BeSpiralWeb.Schema.CommuneTypes do
   object :sale do
     field(:id, non_null(:integer))
     field(:creator_id, non_null(:string))
+
     field(:community_id, non_null(:string))
+    field(:community, non_null(:community), resolve: dataloader(BeSpiral.Commune))
+
     field(:title, non_null(:string))
     field(:description, non_null(:string))
     field(:price, non_null(:float))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BeSpiral.Mixfile do
   def project do
     [
       app: :bespiral,
-      version: "1.5.3",
+      version: "1.5.4",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
Expand sale query to allow us to query related community details, used on the transfer screen: https://www.figma.com/file/X0ROabI93lbH0YsHDiwcFf/shop---mobile?node-id=1%3A1159