### PR TITLE
Fix for BACKEND-1C: adding one day to DateTime for Elixir 1.7.2

### DIFF
--- a/lib/cambiatus/accounts/transfers.ex
+++ b/lib/cambiatus/accounts/transfers.ex
@@ -158,11 +158,16 @@ defmodule Cambiatus.Accounts.Transfers do
 
   @spec query_transfers_by_date(Ecto.Queryable.t(), String.t()) :: Ecto.Queryable.t()
   def query_transfers_by_date(query, date) do
-    {:ok, day_boundary_start, 0} =
-      DateTime.from_iso8601(Date.to_string(date) <> "T00:00:00Z")
+    to_datetime =
+      fn d ->
+        {:ok, datetime, _} =
+          Date.to_iso8601(d) <> "T00:00:00Z"
+          |> DateTime.from_iso8601
+        datetime
+      end
 
-    day_boundary_end =
-      DateTime.add(day_boundary_start, 24 * 60 * 60, :second)
+    day_boundary_start = to_datetime.(date)
+    day_boundary_end = to_datetime.(Date.add(date, 1))
 
     query
     |> where(


### PR DESCRIPTION
## What issue does this PR close
Fixes a bug from #43 caused by using `DateTime.add/3` which works only for Elixir 1.8.0 and above.

## Changes Proposed ( a list of new changes introduced by this PR)
Use a custom function for adding one day to the DateTime variable.

## How to test ( a list of instructions on how to test this PR)
- Tests from `test/cambiatus_web/schema/resolvers/accounts_test.exs` should work.
- DatePicker from [frontend branch](https://github.com/cambiatus/frontend/pull/253) should not cause 500 error.
- Sentry should not report a bug after choosing a date from Date Picker on Frontend.