### PR TITLE
Rename has_actions to has_objectives

### DIFF
--- a/lib/cambiatus/commune/community.ex
+++ b/lib/cambiatus/commune/community.ex
@@ -35,7 +35,7 @@ defmodule Cambiatus.Commune.Community do
     field(:created_at, :utc_datetime)
 
     # Features
-    field(:has_actions, :boolean, default: true)
+    field(:has_objectives, :boolean, default: true)
     field(:has_shop, :boolean, default: true)
 
     has_many(:sales, Sale, foreign_key: :community_id)

--- a/lib/cambiatus_web/schema/commmune_types.ex
+++ b/lib/cambiatus_web/schema/commmune_types.ex
@@ -243,7 +243,7 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     field(:created_eos_account, non_null(:string))
     field(:created_at, non_null(:datetime))
 
-    field(:has_actions, non_null(:boolean))
+    field(:has_objectives, non_null(:boolean))
     field(:has_shop, non_null(:boolean))
 
     connection field(:transfers, node_type: :transfer) do

--- a/priv/repo/migrations/20200619185211_change_has_actions_to_has_objectives.exs
+++ b/priv/repo/migrations/20200619185211_change_has_actions_to_has_objectives.exs
@@ -1,0 +1,7 @@
+defmodule Cambiatus.Repo.Migrations.ChangeHasActionsToHasObjectives do
+  use Ecto.Migration
+
+  def change do
+    rename(table("communities"), :has_actions, to: :has_objectives)
+  end
+end

--- a/test/cambiatus_web/schema/resolvers/commune_test.exs
+++ b/test/cambiatus_web/schema/resolvers/commune_test.exs
@@ -747,7 +747,7 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       query = """
       query($symbol: String!) {
         community(symbol: $symbol) {
-          has_actions,
+          has_objectives,
           has_shop
         }
       }
@@ -758,7 +758,7 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       %{
         "data" => %{
           "community" => %{
-            "has_actions" => actions,
+            "has_objectives" => actions,
             "has_shop" => shop
           }
         }


### PR DESCRIPTION
This PR makes naming more consistent across the project. Contracts and the frontend are already using `has_objectives`, so the backend should follow :)

