### PR TITLE
Remove unneeded access key configs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,14 @@ config :logger, :console,
 
 config :phoenix, :json_library, Jason
 
-config :cambiatus, env: Mix.env
+config :cambiatus, env: Mix.env()
+
+config :ex_aws,
+  s3: [
+    scheme: "https://",
+    host: "cambiatus-uploads.s3.amazonaws.com",
+    region: "us-east-1"
+  ]
 
 # Configures the endpoint
 config :cambiatus, CambiatusWeb.Endpoint,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,15 +43,6 @@ config :phoenix, :stacktrace_depth, 25
 
 config :cambiatus, :ipfs, conn: {}
 
-config :ex_aws,
-  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-  s3: [
-    scheme: "https://",
-    host: "cambiatus-uploads.s3.amazonaws.com",
-    region: "us-east-1"
-  ]
-
 config :eosrpc, EOSRPC.Wallet, url: "http://localhost:8888/v1/wallet"
 
 config :eosrpc, EOSRPC.Chain, url: "http://eosio.cambiatus.local/v1/chain"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,15 +19,6 @@ config :cambiatus, Cambiatus.Mailer, adapter: Bamboo.SendGridAdapter
 
 config :cambiatus, :ipfs, conn: %{host: System.get_env("IPFS_URL"), port: 5001}
 
-config :ex_aws,
-  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-  s3: [
-    scheme: "https://",
-    host: "cambiatus-uploads.s3.amazonaws.com",
-    region: "us-east-1"
-  ]
-
 config :cambiatus, Cambiatus.Chat.ApiHttp,
   chat_base_url: System.get_env("CHAT_BASE_URL"),
   chat_token: System.get_env("CHAT_TOKEN"),


### PR DESCRIPTION
This is already done by ex_aws by default, and specifying it again seems
to break our docker deployment

## How to test ( a list of instructions on how to test this PR)
Run the backend container from our infra repository