### PR TITLE
Add signup mutation

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -17,7 +17,7 @@ config :cambiatus, Cambiatus.Eos,
 config :cambiatus, Cambiatus.Repo,
   database: "cambiatus_dev",
   username: "postgres",
-  password: "",
+  password: "123123123",
   hostname: "localhost",
   port: "5432"
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -17,7 +17,7 @@ config :cambiatus, Cambiatus.Eos,
 config :cambiatus, Cambiatus.Repo,
   database: "cambiatus_dev",
   username: "postgres",
-  password: "123123123",
+  password: "",
   hostname: "localhost",
   port: "5432"
 

--- a/lib/cambiatus/eos.ex
+++ b/lib/cambiatus/eos.ex
@@ -35,7 +35,7 @@ defmodule Cambiatus.Eos do
         "ownerKey" => owner_key,
         "activeKey" => active_key
       }) do
-    case EOSRPC.Chain.get_account(account_name) do
+    case @eosrpc_helper.get_account(account_name) do
       {:ok, _} ->
         {:error, "Account already exists"}
 

--- a/lib/cambiatus_web/resolvers/accounts.ex
+++ b/lib/cambiatus_web/resolvers/accounts.ex
@@ -33,6 +33,16 @@ defmodule CambiatusWeb.Resolvers.Accounts do
   end
 
   @doc """
+  Updates an a user account profile info
+  """
+  @spec create_user(map(), map(), map()) :: {:ok, User.t()} | {:error, term()}
+  def create_user(_, %{input: params}, _) do
+    params
+    |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end)
+    |> Cambiatus.Auth.sign_up()
+  end
+
+  @doc """
   Collects transfers belonging to the given user according various criteria, provided in `args`.
   """
   @spec get_transfers(map(), map(), map()) :: {:ok, list(map())} | {:error, String.t()}

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -38,6 +38,7 @@ defmodule CambiatusWeb.Schema.AccountTypes do
     field(:account, non_null(:string))
     field(:email, non_null(:string))
     field(:invitation_id, non_null(:string))
+    field(:public_key, non_null(:string))
   end
 
   @desc "An input object for updating a user Profile"

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -34,10 +34,10 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
   @desc "Input object for creating a new user account"
   input_object :create_user_input do
-    field(:name, :string)
+    field(:name, non_null(:string))
     field(:account, non_null(:string))
-    field(:email, :string)
-    field(:invitation_id, :string)
+    field(:email, non_null(:string))
+    field(:invitation_id, non_null(:string))
   end
 
   @desc "An input object for updating a user Profile"

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -24,6 +24,20 @@ defmodule CambiatusWeb.Schema.AccountTypes do
       arg(:input, non_null(:profile_update_input))
       resolve(&Accounts.update_profile/3)
     end
+
+    @desc "Creates a new user account"
+    field :create_user, :profile do
+      arg(:input, non_null(:account_create_input))
+      resolve(&Accounts.create_user/3)
+    end
+  end
+
+  @desc "Input object for creating a new user account"
+  input_object :account_create_input do
+    field(:name, non_null(:string))
+    field(:account, non_null(:string))
+    field(:email, non_null(:string))
+    field(:invitation_id, non_null(:string))
   end
 
   @desc "An input object for updating a user Profile"
@@ -44,8 +58,8 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
   @desc "The direction of the transfer"
   enum :transfer_direction do
-    value :incoming, description: "User's incoming transfers."
-    value :outgoing, description: "User's outgoing transfers."
+    value(:incoming, description: "User's incoming transfers.")
+    value(:outgoing, description: "User's outgoing transfers.")
   end
 
   @desc "A users profile on the system"
@@ -80,7 +94,11 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
     connection field(:transfers, node_type: :transfer) do
       arg(:direction, :transfer_direction)
-      arg(:second_party_account, :string, description: "Account name of the other participant of the transfer.")
+
+      arg(:second_party_account, :string,
+        description: "Account name of the other participant of the transfer."
+      )
+
       arg(:date, :date, description: "The date of the transfer in `yyyy-mm-dd` format.")
       resolve(&Accounts.get_transfers/3)
     end

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -27,13 +27,13 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
     @desc "Creates a new user account"
     field :create_user, :profile do
-      arg(:input, non_null(:account_create_input))
+      arg(:input, non_null(:create_user_input))
       resolve(&Accounts.create_user/3)
     end
   end
 
   @desc "Input object for creating a new user account"
-  input_object :account_create_input do
+  input_object :create_user_input do
     field(:name, :string)
     field(:account, non_null(:string))
     field(:email, :string)

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -34,10 +34,10 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
   @desc "Input object for creating a new user account"
   input_object :account_create_input do
-    field(:name, non_null(:string))
+    field(:name, :string)
     field(:account, non_null(:string))
-    field(:email, non_null(:string))
-    field(:invitation_id, non_null(:string))
+    field(:email, :string)
+    field(:invitation_id, :string)
   end
 
   @desc "An input object for updating a user Profile"

--- a/test/cambiatus/auth/auth_test.exs
+++ b/test/cambiatus/auth/auth_test.exs
@@ -78,7 +78,8 @@ defmodule Cambiatus.AuthTest do
         "account" => user.account,
         "name" => "name",
         "email" => "something@email.com",
-        "invitation_id" => ""
+        "invitation_id" => "",
+        "public_key" => "mykey"
       }
 
       assert Auth.sign_up(auth_params) == {:error, :not_found}
@@ -97,7 +98,8 @@ defmodule Cambiatus.AuthTest do
           "account" => new_user_account_name,
           "name" => "name",
           "email" => new_user_email,
-          "invitation_id" => InvitationId.encode(invitation.id)
+          "invitation_id" => InvitationId.encode(invitation.id),
+          "public_key" => "mykey"
         })
 
       assert(new_user.email == new_user_email)

--- a/test/cambiatus_web/schema/resolvers/accounts_test.exs
+++ b/test/cambiatus_web/schema/resolvers/accounts_test.exs
@@ -21,7 +21,8 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
           "account" => "someuser",
           "email" => "some@user.com",
           "invitation_id" => invitation_id,
-          "name" => "Some User"
+          "name" => "Some User",
+          "public_key" => "mypublickey"
         }
       }
 

--- a/test/cambiatus_web/schema/resolvers/accounts_test.exs
+++ b/test/cambiatus_web/schema/resolvers/accounts_test.exs
@@ -26,7 +26,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       }
 
       query = """
-      mutation($input: AccountCreateInput!){
+      mutation($input: CreateUserInput!){
         createUser(input: $input) {
           account
           email
@@ -55,7 +55,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       }
 
       query = """
-      mutation($input: AccountCreateInput!){
+      mutation($input: CreateUserInput!){
         createUser(input: $input) {
           account
         }

--- a/test/cambiatus_web/schema/resolvers/accounts_test.exs
+++ b/test/cambiatus_web/schema/resolvers/accounts_test.exs
@@ -44,31 +44,6 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       assert response["data"]["createUser"]["name"] == variables["input"]["name"]
     end
 
-    test "creates a user with minimal parameters", %{conn: conn} do
-      user = insert(:user, %{account: "cambiatustest"})
-      community = insert(:community, %{symbol: "BES"})
-
-      variables = %{
-        "input" => %{
-          "account" => "someuser"
-        }
-      }
-
-      query = """
-      mutation($input: CreateUserInput!){
-        createUser(input: $input) {
-          account
-        }
-      }
-      """
-
-      res = conn |> post("/api/graph", query: query, variables: variables)
-
-      response = json_response(res, 200)
-
-      assert response["data"]["createUser"]["account"] == variables["input"]["account"]
-    end
-
     test "collects a user account given the account name", %{conn: conn} do
       assert Repo.aggregate(User, :count, :account) == 0
       usr = insert(:user)

--- a/test/cambiatus_web/schema/resolvers/accounts_test.exs
+++ b/test/cambiatus_web/schema/resolvers/accounts_test.exs
@@ -10,6 +10,65 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
   }
 
   describe "Accounts Resolver" do
+    test "creates a user with all parameters", %{conn: conn} do
+      community = insert(:community, %{symbol: "BES"})
+      invitation = insert(:invitation, %{community: community})
+
+      invitation_id = invitation.id |> Cambiatus.Auth.InvitationId.encode()
+
+      variables = %{
+        "input" => %{
+          "account" => "someuser",
+          "email" => "some@user.com",
+          "invitation_id" => invitation_id,
+          "name" => "Some User"
+        }
+      }
+
+      query = """
+      mutation($input: AccountCreateInput!){
+        createUser(input: $input) {
+          account
+          email
+          name
+        }
+      }
+      """
+
+      res = conn |> post("/api/graph", query: query, variables: variables)
+
+      response = json_response(res, 200)
+
+      assert response["data"]["createUser"]["account"] == variables["input"]["account"]
+      assert response["data"]["createUser"]["email"] == variables["input"]["email"]
+      assert response["data"]["createUser"]["name"] == variables["input"]["name"]
+    end
+
+    test "creates a user with minimal parameters", %{conn: conn} do
+      user = insert(:user, %{account: "cambiatustest"})
+      community = insert(:community, %{symbol: "BES"})
+
+      variables = %{
+        "input" => %{
+          "account" => "someuser"
+        }
+      }
+
+      query = """
+      mutation($input: AccountCreateInput!){
+        createUser(input: $input) {
+          account
+        }
+      }
+      """
+
+      res = conn |> post("/api/graph", query: query, variables: variables)
+
+      response = json_response(res, 200)
+
+      assert response["data"]["createUser"]["account"] == variables["input"]["account"]
+    end
+
     test "collects a user account given the account name", %{conn: conn} do
       assert Repo.aggregate(User, :count, :account) == 0
       usr = insert(:user)
@@ -106,7 +165,8 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
         :transfers => transfers,
         :variables => %{
           "input" => %{
-            "account" => user1.account # tests are based on the `user1` profile
+            # tests are based on the `user1` profile
+            "account" => user1.account
           },
           "first" => Enum.count(transfers)
         }
@@ -166,7 +226,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
     end
 
     test "transfers for the date", %{conn: conn, variables: variables} do
-      today_date = Date.to_string(Date.utc_today)
+      today_date = Date.to_string(Date.utc_today())
 
       query = """
         query ($input: ProfileInput!, $first: Int!) {
@@ -194,7 +254,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
     end
 
     test "incoming transfers for the date", %{conn: conn, variables: variables} do
-      today_date = Date.to_string(Date.utc_today)
+      today_date = Date.to_string(Date.utc_today())
 
       query = """
         query ($input: ProfileInput!, $first: Int!) {
@@ -222,7 +282,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
     end
 
     test "outgoing transfers for the date", %{conn: conn, variables: variables} do
-      today_date = Date.to_string(Date.utc_today)
+      today_date = Date.to_string(Date.utc_today())
 
       query = """
         query ($input: ProfileInput!, $first: Int!) {
@@ -249,8 +309,12 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       assert user1_today_outgoing_transfers_count == 2
     end
 
-    test "incoming transfers for the date from user2 to user1", %{conn: conn, users: users, variables: variables} do
-      today_date = Date.utc_today |> Date.to_string
+    test "incoming transfers for the date from user2 to user1", %{
+      conn: conn,
+      users: users,
+      variables: variables
+    } do
+      today_date = Date.utc_today() |> Date.to_string()
 
       query = """
         query ($input: ProfileInput!, $first: Int!) {
@@ -290,7 +354,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
         }
       } = json_response(res, 200)
 
-      get_account = &(&1["node"][&2]["account"])
+      get_account = & &1["node"][&2]["account"]
 
       assert Enum.all?(
                collected_transfers,
@@ -300,8 +364,12 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       assert transfers_from_user2_to_user1_for_today_count == 1
     end
 
-    test "outgoing transfers for the date from user1 to user2", %{conn: conn, users: users, variables: variables} do
-      today_date = Date.utc_today |> Date.to_string
+    test "outgoing transfers for the date from user1 to user2", %{
+      conn: conn,
+      users: users,
+      variables: variables
+    } do
+      today_date = Date.utc_today() |> Date.to_string()
 
       query = """
         query ($input: ProfileInput!, $first: Int!) {
@@ -341,7 +409,7 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
         }
       } = json_response(res, 200)
 
-      get_account = &(&1["node"][&2]["account"])
+      get_account = & &1["node"][&2]["account"]
 
       assert Enum.all?(
                collected_transfers,
@@ -371,9 +439,9 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
 
       %{
         "data" => %{
-           "profile" => %{
-              "getPayersByAccount" => payers
-           }
+          "profile" => %{
+            "getPayersByAccount" => payers
+          }
         }
       } = json_response(res, 200)
 

--- a/test/support/mocks/eosrpc_helper_mock.ex
+++ b/test/support/mocks/eosrpc_helper_mock.ex
@@ -9,4 +9,8 @@ defmodule EOSRPC.HelperMock do
   def auto_push(_) do
     {:ok, %{body: %{"transaction_id" => "txidmock"}}}
   end
+
+  def get_account(_) do
+    {:error, %{body: %{"transaction_id" => "txidmock"}}}
+  end
 end


### PR DESCRIPTION
## What issue does this PR close
Closes #57 

## Changes Proposed ( a list of new changes introduced by this PR)
Introduces a new mutation for creating new users. This is necessary for the future implementation of know-your-customer functionality.

## How to test ( a list of instructions on how to test this PR)
1. Open up the playground (http://localhost:4000/api/graphiql)
2. Run the mutation `createUser`


