### PR TITLE
Add KYC info and the address to the Profile query

### DIFF
--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -73,6 +73,21 @@ defmodule CambiatusWeb.Schema.AccountTypes do
     field(:reason, non_null(:string))
   end
 
+  @desc "User's address"
+  object :address do
+    field(:street, non_null(:string))
+    field(:number, non_null(:string))
+    field(:zip, :string)
+  end
+
+  @desc "User's KYC fields"
+  object :kyc_data do
+    field(:user_type, non_null(:string))
+    field(:document_type, non_null(:string))
+    field(:document, non_null(:string))
+    field(:phone, non_null(:string))
+  end
+
   @desc "A users profile on the system"
   object :profile do
     field(:account, non_null(:string))
@@ -88,6 +103,9 @@ defmodule CambiatusWeb.Schema.AccountTypes do
     field(:created_at, :string)
     field(:created_eos_account, :string)
     field(:network, list_of(:network))
+
+    field(:address, :address, resolve: dataloader(Cambiatus.Kyc))
+    field(:kyc, :kyc_data, resolve: dataloader(Cambiatus.Kyc))
 
     field(:communities, non_null(list_of(non_null(:community))),
       resolve: dataloader(Cambiatus.Commune)

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -80,8 +80,8 @@ defmodule CambiatusWeb.Schema.AccountTypes do
     field(:city, :city, resolve: dataloader(Cambiatus.Kyc))
     field(:neighborhood, :neighborhood, resolve: dataloader(Cambiatus.Kyc))
     field(:street, non_null(:string))
-    field(:number, non_null(:string))
-    field(:zip, :string)
+    field(:number, :string)
+    field(:zip, non_null(:string))
   end
 
   @desc "User's KYC fields"

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -75,6 +75,10 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
   @desc "User's address"
   object :address do
+    field(:country, :country, resolve: dataloader(Cambiatus.Kyc))
+    field(:state, :state, resolve: dataloader(Cambiatus.Kyc))
+    field(:city, :city, resolve: dataloader(Cambiatus.Kyc))
+    field(:neighborhood, :neighborhood, resolve: dataloader(Cambiatus.Kyc))
     field(:street, non_null(:string))
     field(:number, non_null(:string))
     field(:zip, :string)
@@ -86,6 +90,8 @@ defmodule CambiatusWeb.Schema.AccountTypes do
     field(:document_type, non_null(:string))
     field(:document, non_null(:string))
     field(:phone, non_null(:string))
+    field(:is_verified, non_null(:boolean))
+    field(:country, :country, resolve: dataloader(Cambiatus.Kyc))
   end
 
   @desc "A users profile on the system"

--- a/lib/cambiatus_web/schema/account_types.ex
+++ b/lib/cambiatus_web/schema/account_types.ex
@@ -75,10 +75,10 @@ defmodule CambiatusWeb.Schema.AccountTypes do
 
   @desc "User's address"
   object :address do
-    field(:country, :country, resolve: dataloader(Cambiatus.Kyc))
-    field(:state, :state, resolve: dataloader(Cambiatus.Kyc))
-    field(:city, :city, resolve: dataloader(Cambiatus.Kyc))
-    field(:neighborhood, :neighborhood, resolve: dataloader(Cambiatus.Kyc))
+    field(:country, non_null(:country), resolve: dataloader(Cambiatus.Kyc))
+    field(:state, non_null(:state), resolve: dataloader(Cambiatus.Kyc))
+    field(:city, non_null(:city), resolve: dataloader(Cambiatus.Kyc))
+    field(:neighborhood, non_null(:neighborhood), resolve: dataloader(Cambiatus.Kyc))
     field(:street, non_null(:string))
     field(:number, :string)
     field(:zip, non_null(:string))


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. This PR adds KYC and address to the Profile GraphQl query. Related to cambiatus/frontend/pull/346 and some other issues which need this info on the frontend.

## Changes Proposed (a list of new changes introduced by this PR)
Add `kyc` and `address` fields to the Profile query to have this info on the frontend. Here's the full query:

```graphql
{
  profile(input: {account: "andreymiskov"}) {
    address {
      street
      number
      zip
      country {
        name
      }      
      state {
        name
      }
      city {
        name
      }
      neighborhood {
        name
      }
    }
    
    kyc {
      userType
      documentType
      document
      phone
      isVerified
      country {
        name
      }
    }
  }
}
```

## How to test (a list of instructions on how to test this PR)
Run tests or/and try to use the query above from the GraphiQl interface.


