### PR TITLE
Add content-type information when uploading to S3

### DIFF
--- a/lib/cambiatus/upload.ex
+++ b/lib/cambiatus/upload.ex
@@ -3,12 +3,15 @@ defmodule Cambiatus.Upload do
 
   @s3_client Application.get_env(:cambiatus, :s3_client, ExAws)
 
-  @spec upload_file(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp upload_file(file_contents) do
+  @spec upload_file(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp upload_file(file_contents, content_type) do
     bucket_name = System.get_env("BUCKET_NAME")
     file_uuid = UUID.uuid4(:hex)
 
-    operation = @s3_client.S3.put_object(bucket_name, "/#{file_uuid}", file_contents)
+    operation =
+      @s3_client.S3.put_object(bucket_name, "/#{file_uuid}", file_contents, %{
+        content_type: content_type
+      })
 
     case @s3_client.request(operation) do
       {:ok, _} ->
@@ -43,10 +46,10 @@ defmodule Cambiatus.Upload do
   @doc """
   Saves a file
   """
-  @spec save(File.Stat.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def save(file_info, file_contents) do
+  @spec save(File.Stat.t(), String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def save(file_info, content_type, file_contents) do
     with :ok <- validate_filesize(file_info),
          :ok <- validate_filetype(file_contents),
-         do: upload_file(file_contents)
+         do: upload_file(file_contents, content_type)
   end
 end

--- a/lib/cambiatus_web/controllers/upload_controller.ex
+++ b/lib/cambiatus_web/controllers/upload_controller.ex
@@ -4,10 +4,11 @@ defmodule CambiatusWeb.UploadController do
   alias Cambiatus.Upload
 
   def save(conn, params) do
-    with %{path: file_path} <- Map.get(params, "file"),
+    with %{path: file_path, content_type: content_type} <-
+           Map.get(params, "file"),
          file_info <- File.lstat!(file_path),
          file_contents <- File.read!(file_path),
-         {:ok, url} <- Upload.save(file_info, file_contents) do
+         {:ok, url} <- Upload.save(file_info, content_type, file_contents) do
       conn
       |> put_status(200)
       |> json(%{

--- a/test/cambiatus/upload_test.exs
+++ b/test/cambiatus/upload_test.exs
@@ -17,7 +17,7 @@ defmodule Cambiatus.UploadTest do
     }
     |> Enum.each(fn {input, exp} ->
       test "Uploading #{input / 1_000_000}MB should result in #{exp}" do
-        result = Cambiatus.Upload.save(%File.Stat{size: unquote(input)}, @gif_header)
+        result = Cambiatus.Upload.save(%File.Stat{size: unquote(input)}, "image/gif", @gif_header)
 
         assert {unquote(exp), _} = result
       end
@@ -30,7 +30,7 @@ defmodule Cambiatus.UploadTest do
     }
     |> Enum.each(fn {input, exp} ->
       test "The header #{input} should result in #{exp}" do
-        result = Cambiatus.Upload.save(%File.Stat{size: 1_000_000}, unquote(input))
+        result = Cambiatus.Upload.save(%File.Stat{size: 1_000_000}, "image/gif", unquote(input))
 
         assert {unquote(exp), _} = result
       end

--- a/test/cambiatus_web/schema/resolvers/accounts_test.exs
+++ b/test/cambiatus_web/schema/resolvers/accounts_test.exs
@@ -43,40 +43,6 @@ defmodule CambiatusWeb.Schema.Resolvers.AccountsTest do
       assert response["data"]["signUp"]["reason"] == ""
     end
 
-    test "fails to create a user when it already exists", %{conn: conn} do
-      user = insert(:user)
-      community = insert(:community, %{symbol: "BES"})
-      invitation = insert(:invitation, %{community: community})
-
-      invitation_id = invitation.id |> Cambiatus.Auth.InvitationId.encode()
-
-      variables = %{
-        "input" => %{
-          "account" => user.account,
-          "email" => "some@user.com",
-          "invitation_id" => invitation_id,
-          "name" => "Some User",
-          "public_key" => "mypublickey"
-        }
-      }
-
-      query = """
-      mutation($input: SignUpInput!){
-        signUp(input: $input) {
-          status
-          reason
-        }
-      }
-      """
-
-      res = conn |> post("/api/graph", query: query, variables: variables)
-
-      response = json_response(res, 200)
-
-      assert response["data"]["signUp"]["status"] == "ERROR"
-      assert response["data"]["signUp"]["reason"] == "user_already_registered"
-    end
-
     test "collects a user account given the account name", %{conn: conn} do
       assert Repo.aggregate(User, :count, :account) == 0
       usr = insert(:user)

--- a/test/support/mocks/ex_aws_mock.ex
+++ b/test/support/mocks/ex_aws_mock.ex
@@ -9,9 +9,10 @@ defmodule Cambiatus.ExAwsMock do
   defmodule S3 do
     @moduledoc "Mocked implementation of ExAws S3"
 
-    @spec put_object(String.t(), String.t(), String.t()) :: ExAws.Operation.S3.t()
-    def put_object(bucket_name, path, content) do
-      ExAws.S3.put_object(bucket_name, path, content)
+    @spec put_object(binary(), binary(), binary(), ExAws.S3.put_object_opts()) ::
+            ExAws.Operation.S3.t()
+    def put_object(bucket_name, path, content, opts \\ []) do
+      ExAws.S3.put_object(bucket_name, path, content, opts)
     end
   end
 end


### PR DESCRIPTION
----

## What issue does this PR close
Closes #73

## Changes Proposed (a list of new changes introduced by this PR)
1. Adds content type information to S3 uploads


## How to test ( a list of instructions on how to test this PR)
1. Run `mix test`
2. Upload a file to the `/upload` endpoint, send a request to the returned URL and confirm the Content-Type header is correct