### PR TITLE
Make states, cities and neighborhoods non-null

### DIFF
--- a/lib/cambiatus_web/schema/kyc_types.ex
+++ b/lib/cambiatus_web/schema/kyc_types.ex
@@ -25,19 +25,22 @@ defmodule CambiatusWeb.Schema.KycTypes do
   @desc "KYC supported countries"
   object :country do
     field(:name, non_null(:string))
-    field(:states, non_null(list_of(:state)), resolve: dataloader(Cambiatus.Kyc))
+    field(:states, non_null(list_of(non_null(:state))), resolve: dataloader(Cambiatus.Kyc))
   end
 
   @desc "KYC supported states"
   object :state do
     field(:name, non_null(:string))
-    field(:cities, non_null(list_of(:city)), resolve: dataloader(Cambiatus.Kyc))
+    field(:cities, non_null(list_of(non_null(:city))), resolve: dataloader(Cambiatus.Kyc))
   end
 
   @desc "KYC supported cities"
   object :city do
     field(:name, non_null(:string))
-    field(:neighborhoods, non_null(list_of(:neighborhood)), resolve: dataloader(Cambiatus.Kyc))
+
+    field(:neighborhoods, non_null(list_of(non_null(:neighborhood))),
+      resolve: dataloader(Cambiatus.Kyc)
+    )
   end
 
   @desc "KYC supported neighborhoods"


### PR DESCRIPTION
----

## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
Makes states, cities and neighborhoods non-null, as none of these should ever be null. For example, a city with no neighborhoods should return an empty list.


## How to test ( a list of instructions on how to test this PR)
1. Access the graphql playground and check the schema