### PR TITLE
Fix changeset permitted keys

### DIFF
--- a/lib/cambiatus/kyc/address.ex
+++ b/lib/cambiatus/kyc/address.ex
@@ -35,7 +35,7 @@ defmodule Cambiatus.Kyc.Address do
   def changeset(model, params \\ :empty) do
     model
     |> Repo.preload(:country)
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
     |> foreign_key_constraint(:country_id)
     |> foreign_key_constraint(:state_id)
     |> validate_country()

--- a/lib/cambiatus/kyc/city.ex
+++ b/lib/cambiatus/kyc/city.ex
@@ -19,12 +19,12 @@ defmodule Cambiatus.Kyc.City do
     timestamps()
   end
 
-  @required_fields ~w(name state_id)
-  @optional_fields ~w()
+  @required_fields ~w(name state_id)a
+  @optional_fields ~w()a
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
     |> cast_assoc(:neighborhoods)
   end
 end

--- a/lib/cambiatus/kyc/country.ex
+++ b/lib/cambiatus/kyc/country.ex
@@ -16,12 +16,12 @@ defmodule Cambiatus.Kyc.Country do
     timestamps()
   end
 
-  @required_fields ~w(name)
-  @optional_fields ~w()
+  @required_fields ~w(name)a
+  @optional_fields ~w()a
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
     |> unique_constraint(:name)
   end
 end

--- a/lib/cambiatus/kyc/kyc_data.ex
+++ b/lib/cambiatus/kyc/kyc_data.ex
@@ -22,13 +22,13 @@ defmodule Cambiatus.Kyc.KycData do
   end
 
   @required_fields ~w(account_id user_type document document_type phone country_id)a
-  @optional_fields ~w(is_verified)
+  @optional_fields ~w(is_verified)a
 
   def changeset(model, params \\ :empty) do
     model
     |> Repo.preload(:country)
     |> Repo.preload(:account)
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_user_type()
     |> validate_document_type()

--- a/lib/cambiatus/kyc/neighborhood.ex
+++ b/lib/cambiatus/kyc/neighborhood.ex
@@ -13,11 +13,11 @@ defmodule Cambiatus.Kyc.Neighborhood do
     timestamps()
   end
 
-  @required_fields ~w(name city_id)
-  @optional_fields ~w()
+  @required_fields ~w(name city_id)a
+  @optional_fields ~w()a
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
   end
 end

--- a/lib/cambiatus/kyc/state.ex
+++ b/lib/cambiatus/kyc/state.ex
@@ -19,11 +19,11 @@ defmodule Cambiatus.Kyc.State do
     timestamps()
   end
 
-  @required_fields ~w(name country_id)
-  @optional_fields ~w()
+  @required_fields ~w(name country_id)a
+  @optional_fields ~w()a
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
   end
 end


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

This PR fixes a minor issue with the permitted keys in [`cast/4`](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) function:
- the permitted keys should be passed as the third argument to the `cast/4` function;
- these keys must be atoms.

We had `@optional_fields` passed as 4th argument in some places. This caused the issue when the optional arguments, like `number` in Address, weren't updated.

## Changes Proposed (a list of new changes introduced by this PR)
- Pass all fields as the third argument;
- Make sure all permitted fields are atoms.

## How to test (a list of instructions on how to test this PR)
Try to run `changeset` from the e.g. `Address` on the master branch, the `number` field won't be added:

```elixir
# Run `iex -S mix` from the terminal
alias Cambiatus.Kyc.Address
Address.changeset(%Address{}, %{
  account_id: 1,
  country_id: 1,
  street: "Elm Street",
  neighborhood_id: 1,
  city_id: 1,
  state_id: 1,
  zip: "10102",
  number: "33"
})
```

Then, try to run the same in this PR's branch, the `number` field should be added successfully.

