### PR TITLE
Use id type instead of string

### DIFF
--- a/lib/cambiatus_web/schema/kyc_types.ex
+++ b/lib/cambiatus_web/schema/kyc_types.ex
@@ -65,7 +65,7 @@ defmodule CambiatusWeb.Schema.KycTypes do
   @desc "Input for creating/updating KYC fields"
   input_object :kyc_data_update_input do
     field(:account_id, non_null(:string))
-    field(:country_id, non_null(:string))
+    field(:country_id, non_null(:id))
     field(:user_type, non_null(:string))
     field(:document_type, non_null(:string))
     field(:document, non_null(:string))
@@ -75,10 +75,10 @@ defmodule CambiatusWeb.Schema.KycTypes do
   @desc "Input for creating/updating address fields"
   input_object :address_update_input do
     field(:account_id, non_null(:string))
-    field(:country_id, non_null(:string))
-    field(:state_id, non_null(:string))
-    field(:city_id, non_null(:string))
-    field(:neighborhood_id, non_null(:string))
+    field(:country_id, non_null(:id))
+    field(:state_id, non_null(:id))
+    field(:city_id, non_null(:id))
+    field(:neighborhood_id, non_null(:id))
     field(:street, non_null(:string))
     field(:number, :string)
     field(:zip, non_null(:string))


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

## Changes Proposed (a list of new changes introduced by this PR)
Use `:id` type for countries, cities, states, and neighborhoods in KYC and Address input objects. See [this comment](https://github.com/cambiatus/backend/pull/80#issuecomment-692209332) for more context.