### PR TITLE
Fix analysis page listing

### DIFF
--- a/lib/cambiatus/commune/commune.ex
+++ b/lib/cambiatus/commune/commune.ex
@@ -254,11 +254,8 @@ defmodule Cambiatus.Commune do
       on: o.id == a.objective_id,
       join: v in Validator,
       on: v.action_id == c.action_id,
-      left_join: ch in Check,
-      on: ch.claim_id == c.id,
       where: o.community_id == ^community_id,
       where: v.validator_id == ^account,
-      where: fragment("?.validator_id = ? OR ?.claim_id IS NULL", ch, ^account, ch),
       order_by: [desc: c.created_at]
     )
   end


### PR DESCRIPTION
## What issue does this PR close
Closes an issue with Claims listing on the Analysis page from the [frontend/409](https://github.com/cambiatus/frontend/issues/409)

## Changes Proposed ( a list of new changes introduced by this PR)
Change the query for retrieving all claims to analyze for the given validator from the given community.

## How to test ( a list of instructions on how to test this PR)
- Login as a validator for some Claim.
- Go to the `dashboard/analysis` page, try to approve/disapprove some Claims.
- The number of Claims on this page should stay the same, only the status for the current user should change.
- Other verifiers should also have the right amount of Claims on their Analysis pages.