### PR TITLE
Adjust invite to have a community preview

### DIFF
--- a/lib/cambiatus_web/resolvers/commune.ex
+++ b/lib/cambiatus_web/resolvers/commune.ex
@@ -113,6 +113,10 @@ defmodule CambiatusWeb.Resolvers.Commune do
     Commune.get_community_by_subdomain(subdomain)
   end
 
+  def find_community(%Cambiatus.Auth.Invitation{} = invite, _, _) do
+    {:ok, invite.community}
+  end
+
   @doc """
   Collects all transfers from a community
   """
@@ -163,7 +167,7 @@ defmodule CambiatusWeb.Resolvers.Commune do
 
   @doc "Collect an invite"
   @spec get_invitation(map(), map(), map()) :: {:ok, list(map())} | {:error, String.t()}
-  def get_invitation(_, %{input: %{id: id}}, _) do
+  def get_invitation(_, %{id: id}, _) do
     Auth.get_invitation(id)
   end
 

--- a/lib/cambiatus_web/schema/commmune_types.ex
+++ b/lib/cambiatus_web/schema/commmune_types.ex
@@ -71,7 +71,7 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
 
     @desc "An invite"
     field :invite, :invite do
-      arg(:input, non_null(:invite_input))
+      arg(:id, non_null(:string))
 
       resolve(&Commune.get_invitation/3)
     end
@@ -82,14 +82,6 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
 
       middleware(Middleware.Authenticate)
       resolve(&Commune.domain_available/3)
-    end
-
-    @desc "Community Preview, public data available for all communities"
-    field :community_preview, :community_preview do
-      arg(:symbol, :string)
-      arg(:subdomain, :string)
-
-      resolve(&Commune.find_community/3)
     end
   end
 
@@ -194,11 +186,6 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     field(:validator, :string)
   end
 
-  @desc "Input to collect an invite"
-  input_object :invite_input do
-    field(:id, :string)
-  end
-
   @desc "A mint object in Cambiatus"
   object :mint do
     field(:memo, :string)
@@ -269,6 +256,9 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     field(:logo, non_null(:string))
     field(:name, non_null(:string))
     field(:description, non_null(:string))
+    field(:has_objectives, non_null(:boolean))
+    field(:has_shop, non_null(:boolean))
+    field(:has_kyc, non_null(:boolean))
     field(:subdomain, :subdomain, resolve: dataloader(Cambiatus.Commune))
     field(:auto_invite, non_null(:boolean))
   end
@@ -389,7 +379,8 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
 
   @desc "A community invite"
   object :invite do
-    field(:community, non_null(:community), resolve: dataloader(Cambiatus.Commune))
+    field(:community_preview, non_null(:community_preview), resolve: &Commune.find_community/3)
+
     field(:creator, non_null(:user), resolve: dataloader(Cambiatus.Commune))
   end
 

--- a/lib/cambiatus_web/schema/commmune_types.ex
+++ b/lib/cambiatus_web/schema/commmune_types.ex
@@ -83,6 +83,14 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
       middleware(Middleware.Authenticate)
       resolve(&Commune.domain_available/3)
     end
+
+    @desc "Community Preview, public data available for all communities"
+    field :community_preview, :community_preview do
+      arg(:symbol, :string)
+      arg(:subdomain, :string)
+
+      resolve(&Commune.find_community/3)
+    end
   end
 
   @desc "Community Subscriptions on Cambiatus"

--- a/test/cambiatus_web/schema/resolvers/commune_test.exs
+++ b/test/cambiatus_web/schema/resolvers/commune_test.exs
@@ -1015,11 +1015,11 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
 
       query = """
         query {
-          invite(input: {id: "#{invite_id}"}) {
+          invite(id: "#{invite_id}") {
             creator {
               account
             }
-            community {
+            communityPreview {
               symbol
             }
           }
@@ -1030,7 +1030,7 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       %{"data" => %{"invite" => found_invite}} = json_response(res, 200)
 
       assert(invite.creator_id == found_invite["creator"]["account"])
-      assert(invite.community_id == found_invite["community"]["symbol"])
+      assert(invite.community_id == found_invite["communityPreview"]["symbol"])
     end
   end
 end

--- a/test/cambiatus_web/schema/resolvers/commune_test.exs
+++ b/test/cambiatus_web/schema/resolvers/commune_test.exs
@@ -979,8 +979,9 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       """
 
       res = conn |> get("/api/graph", query: query_analysis, variables: params)
-      %{"data" => %{"claimsAnalysis" => cs}} = json_response(res, 200)
-      claim_action_ids = cs["edges"] |> Enum.map(& &1["node"]) |> Enum.map(& &1["action"]["id"])
+      %{"data" => %{"claimsAnalysis" => _}} = json_response(res, 200)
+      # %{"data" => %{"claimsAnalysis" => cs}} = json_response(res, 200)
+      # claim_action_ids = cs["edges"] |> Enum.map(& &1["node"]) |> Enum.map(& &1["action"]["id"])
 
       # Make sure pending is only one
       # assert Enum.count(claim_action_ids) == 1


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
- Removes `communityPreview` query but keep the type
- Change `invite` to show `communityPreview` type instead of `community`
- Simplify params on `invite`

## How to test ( a list of instructions on how to test this PR)
- `mix test`
- Deploy on staging
- Check with @NeoVier if its what he needs

