### PR TITLE
Add sorting to community photos

### DIFF
--- a/lib/cambiatus/commune/commune.ex
+++ b/lib/cambiatus/commune/commune.ex
@@ -12,6 +12,7 @@ defmodule Cambiatus.Commune do
     Action,
     Check,
     Community,
+    CommunityPhotos,
     Claim,
     Network,
     Objective,
@@ -79,6 +80,11 @@ defmodule Cambiatus.Commune do
     Claim
     |> Claim.by_community(community_id)
     |> Claim.newer_first()
+  end
+
+  def query(CommunityPhotos, _params) do
+    CommunityPhotos
+    |> order_by([cp], desc: cp.inserted_at)
   end
 
   def query(queryable, _params) do

--- a/lib/cambiatus/commune/community.ex
+++ b/lib/cambiatus/commune/community.ex
@@ -1,7 +1,16 @@
 defmodule Cambiatus.Commune.Community do
   @moduledoc false
 
-  alias Cambiatus.Commune.{Community, Network, Mint, Objective, Transfer, Subdomain, Upload}
+  alias Cambiatus.Commune.{
+    Community,
+    Network,
+    Mint,
+    Objective,
+    Transfer,
+    Subdomain,
+    CommunityPhotos
+  }
+
   alias Cambiatus.Shop.Product
   alias Cambiatus.Repo
 
@@ -48,7 +57,7 @@ defmodule Cambiatus.Commune.Community do
     has_many(:objectives, Objective, foreign_key: :community_id)
     has_many(:actions, through: [:objectives, :actions])
     has_many(:mints, Mint, foreign_key: :community_id)
-    has_many(:uploads, Upload, foreign_key: :community_id, on_replace: :delete)
+    has_many(:uploads, CommunityPhotos, foreign_key: :community_id, on_replace: :delete)
   end
 
   @required_fields ~w(symbol creator name description inviter_reward invited_reward)a
@@ -63,7 +72,7 @@ defmodule Cambiatus.Commune.Community do
   end
 
   def save_photos(%Community{} = community, urls) do
-    uploads = Enum.map(urls, &%Upload{url: &1})
+    uploads = Enum.map(urls, &%CommunityPhotos{url: &1})
 
     community
     |> Repo.preload([:uploads, :subdomain])

--- a/lib/cambiatus/commune/community_photos.ex
+++ b/lib/cambiatus/commune/community_photos.ex
@@ -1,4 +1,4 @@
-defmodule Cambiatus.Commune.Upload do
+defmodule Cambiatus.Commune.CommunityPhotos do
   @moduledoc """
   Upload model for the uploads table
   """
@@ -6,7 +6,7 @@ defmodule Cambiatus.Commune.Upload do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Cambiatus.Commune.{Community, Upload}
+  alias Cambiatus.Commune.{Community, CommunityPhotos}
 
   @url_regex ~r/ https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/
 
@@ -20,7 +20,7 @@ defmodule Cambiatus.Commune.Upload do
   @required_fields ~w(url community_id)a
   @optional_fields ~w()a
 
-  def changeset(%Upload{} = upload, attrs) do
+  def changeset(%CommunityPhotos{} = upload, attrs) do
     upload
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)

--- a/lib/cambiatus_web/schema/commmune_types.ex
+++ b/lib/cambiatus_web/schema/commmune_types.ex
@@ -283,6 +283,8 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
   @desc "A photo"
   object :upload do
     field(:url, non_null(:string))
+    field(:inserted_at, :naive_datetime)
+    field(:updated_at, non_null(:naive_datetime))
   end
 
   @desc "A community objective"

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -18,7 +18,7 @@ defmodule CambiatusWeb.ChannelCase do
   using do
     quote do
       # Import conveniences for testing with channels
-      use Phoenix.ChannelTest
+      import Phoenix.ChannelTest
 
       # The default endpoint for testing
       @endpoint CambiatusWeb.Endpoint

--- a/test/support/subscription_case.ex
+++ b/test/support/subscription_case.ex
@@ -11,7 +11,7 @@ defmodule CambiatusWeb.SubscriptionCase do
 
   using do
     quote do
-      use Phoenix.ChannelTest
+      import Phoenix.ChannelTest
 
       use Absinthe.Phoenix.SubscriptionTest,
         schema: CambiatusWeb.Schema


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
- Fixes some warnings
- Add sorting to community photos
- Add timestamps to community photos on GraphQL

## How to test ( a list of instructions on how to test this PR)
- `mix test` as always
- Upload some photos and make sure they are sorted by date. You can always 

