### PR TITLE
Improve semantics of our claim queries

### DIFF
--- a/lib/cambiatus/commune/claim.ex
+++ b/lib/cambiatus/commune/claim.ex
@@ -69,4 +69,6 @@ defmodule Cambiatus.Commune.Claim do
   def ordered(query \\ Claim, direction \\ :asc)
   def ordered(query, :asc), do: query |> order_by([a], a.created_at)
   def ordered(query, :desc), do: query |> order_by([a], desc: a.created_at)
+
+  def count(query \\ Claim), do: select(query, [claim], count(claim.id))
 end

--- a/lib/cambiatus/commune/commune.ex
+++ b/lib/cambiatus/commune/commune.ex
@@ -195,8 +195,8 @@ defmodule Cambiatus.Commune do
   * community_id: String with the community symbol
   * account: String. User account
   """
-  @spec claim_analysis_query(term, term) :: Ecto.Query.t()
-  def claim_analysis_query(community_id, account) do
+  @spec pending_claims_query(term, term) :: Ecto.Query.t()
+  def pending_claims_query(community_id, account) do
     Claim
     |> join(:left, [c], a in assoc(c, :action))
     |> join(:left, [c, a], o in assoc(a, :objective))
@@ -218,15 +218,14 @@ defmodule Cambiatus.Commune do
   end
 
   @doc """
-  Fetch all claims that the specified `account` is an analyser.
-  It includes the claims that the user still have to give a vote
+  Fetch all claims that the specified `account` is an analyser and already voted.
 
   ## Params
   * community_id: String with the community symbol
   * account: String. User account
   """
-  @spec claim_analysis_history_query(term, term) :: Ecto.Query.t()
-  def claim_analysis_history_query(community_id, account) do
+  @spec analyzed_claims_query(term, term) :: Ecto.Query.t()
+  def analyzed_claims_query(community_id, account) do
     from(c in Claim,
       join: a in Action,
       on: a.id == c.action_id,

--- a/lib/cambiatus_web/resolvers/commune.ex
+++ b/lib/cambiatus_web/resolvers/commune.ex
@@ -79,6 +79,9 @@ defmodule CambiatusWeb.Resolvers.Commune do
           {:claimer, claimer}, query ->
             Claim.with_claimer(query, claimer)
 
+          {:status, status}, query ->
+            Claim.with_status(query, status)
+
           {:direction, direction}, query ->
             Claim.ordered(query, direction)
         end)

--- a/lib/cambiatus_web/schema/commune_types.ex
+++ b/lib/cambiatus_web/schema/commune_types.ex
@@ -29,20 +29,20 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     end
 
     @desc "[Auth required] A list of claims"
-    connection field(:claims_analysis, node_type: :claim) do
+    connection field(:pending_claims, node_type: :claim) do
       arg(:community_id, non_null(:string))
-      arg(:filter, :claim_analysis_filter)
+      arg(:filter, :pending_claims_filter)
 
       middleware(Middleware.Authenticate)
-      resolve(&Commune.get_claims_analysis/3)
+      resolve(&Commune.get_pending_claims/3)
     end
 
-    connection field(:claims_analysis_history, node_type: :claim) do
+    connection field(:analyzed_claims, node_type: :claim) do
       arg(:community_id, non_null(:string))
-      arg(:filter, :claim_analysis_history_filter)
+      arg(:filter, :analyzed_claims_filter)
 
       middleware(Middleware.Authenticate)
-      resolve(&Commune.get_claims_analysis_history/3)
+      resolve(&Commune.get_analyzed_claims/3)
     end
 
     @desc "[Auth required] A single claim"
@@ -163,14 +163,15 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
   end
 
   @desc "Params for filtering Claim Analysis History"
-  input_object(:claim_analysis_history_filter) do
+  input_object(:analyzed_claims_filter) do
     field(:claimer, :string)
     field(:status, :string)
     field(:direction, :direction)
   end
 
   @desc "Params for filtering Claim Analysis"
-  input_object(:claim_analysis_filter) do
+  input_object(:pending_claims_filter) do
+    field(:claimer, :string)
     field(:direction, :direction)
   end
 

--- a/lib/cambiatus_web/schema/commune_types.ex
+++ b/lib/cambiatus_web/schema/commune_types.ex
@@ -31,7 +31,7 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     @desc "[Auth required] A list of claims"
     connection field(:pending_claims, node_type: :claim) do
       arg(:community_id, non_null(:string))
-      arg(:filter, :pending_claims_filter)
+      arg(:filter, :claims_filter)
 
       middleware(Middleware.Authenticate)
       resolve(&Commune.get_pending_claims/3)
@@ -39,7 +39,7 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
 
     connection field(:analyzed_claims, node_type: :claim) do
       arg(:community_id, non_null(:string))
-      arg(:filter, :analyzed_claims_filter)
+      arg(:filter, :claims_filter)
 
       middleware(Middleware.Authenticate)
       resolve(&Commune.get_analyzed_claims/3)
@@ -162,16 +162,10 @@ defmodule CambiatusWeb.Schema.CommuneTypes do
     field(:id, non_null(:integer))
   end
 
-  @desc "Params for filtering Claim Analysis History"
-  input_object(:analyzed_claims_filter) do
+  @desc "Params for filtering Claims"
+  input_object(:claims_filter) do
     field(:claimer, :string)
     field(:status, :string)
-    field(:direction, :direction)
-  end
-
-  @desc "Params for filtering Claim Analysis"
-  input_object(:pending_claims_filter) do
-    field(:claimer, :string)
     field(:direction, :direction)
   end
 

--- a/lib/cambiatus_web/schema/relay_types.ex
+++ b/lib/cambiatus_web/schema/relay_types.ex
@@ -21,6 +21,8 @@ defmodule CambiatusWeb.Schema.RelayTypes do
   end
 
   connection node_type: :claim do
+    field(:count, :integer)
+
     edge do
     end
   end

--- a/test/cambiatus_web/schema/resolvers/commune_test.exs
+++ b/test/cambiatus_web/schema/resolvers/commune_test.exs
@@ -955,7 +955,7 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
 
       query_analysis = """
       query($communityId: String!) {
-        claimsAnalysis(first: #{@num}, communityId: $communityId) {
+        pendingClaims(first: #{@num}, communityId: $communityId) {
           edges {
             node {
               id
@@ -969,16 +969,11 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       """
 
       res = conn |> get("/api/graph", query: query_analysis, variables: params)
-      %{"data" => %{"claimsAnalysis" => _}} = json_response(res, 200)
-      # %{"data" => %{"claimsAnalysis" => cs}} = json_response(res, 200)
-      # claim_action_ids = cs["edges"] |> Enum.map(& &1["node"]) |> Enum.map(& &1["action"]["id"])
-
-      # Make sure pending is only one
-      # assert Enum.count(claim_action_ids) == 1
+      %{"data" => %{"pendingClaims" => _}} = json_response(res, 200)
 
       query_history = """
       query($communityId: String!) {
-        claimsAnalysisHistory(first: #{@num}, communityId: $communityId) {
+        analyzedClaims(first: #{@num}, communityId: $communityId) {
           edges {
             node {
               id
@@ -992,7 +987,7 @@ defmodule CambiatusWeb.Schema.Resolvers.CommuneTest do
       """
 
       res = conn |> get("/api/graph", query: query_history, variables: params)
-      %{"data" => %{"claimsAnalysisHistory" => ch}} = json_response(res, 200)
+      %{"data" => %{"analyzedClaims" => ch}} = json_response(res, 200)
       claim_history_ids = ch["edges"] |> Enum.map(& &1["node"]) |> Enum.map(& &1["action"]["id"])
 
       # but we should have both claims on the history


### PR DESCRIPTION
## What issue does this PR close
Closes #171

## Changes Proposed ( a list of new changes introduced by this PR)

- [x] Rename queries claimAnalysis → pendingClaims and claimAnalysisHistory → analyzedClaims
- [x] Add a filter to pendingClaims, optional for filtering for user
- [x] Add count to show total available results on both queries
- [x] Make sure to show only pending votes on pendingClaims
- [x] Make sure to show only already voted on analyzedClaims


## How to test ( a list of instructions on how to test this PR)
- run `mix test`


