### PR TITLE
Feature/action claim count

### DIFF
--- a/lib/cambiatus/accounts/user.ex
+++ b/lib/cambiatus/accounts/user.ex
@@ -65,7 +65,7 @@ defmodule Cambiatus.Accounts.User do
   end
 
   @required_fields ~w(account email name)a
-  
+
   @optional_fields ~w(bio location interests avatar created_block created_tx created_at created_eos_account
                       language transfer_notification claim_notification digest latest_accepted_terms)a
 

--- a/lib/cambiatus/objectives/action.ex
+++ b/lib/cambiatus/objectives/action.ex
@@ -22,6 +22,7 @@ defmodule Cambiatus.Objectives.Action do
     field(:photo_proof_instructions, :string)
 
     field(:position, :integer)
+    field(:image, :string)
 
     field(:created_block, :integer)
     field(:created_tx, :string)

--- a/lib/cambiatus/objectives/objectives.ex
+++ b/lib/cambiatus/objectives/objectives.ex
@@ -244,6 +244,24 @@ defmodule Cambiatus.Objectives do
     end
   end
 
+  def get_claim_count(%Action{} = action, filter \\ %{}) do
+    query = from(c in Claim, where: c.action_id == ^action.id, select: count(c.id))
+
+    query =
+      if Map.has_key?(filter, :status) do
+        Claim.with_status(query, Map.get(filter, :status))
+      else
+        query
+      end
+
+    query
+    |> Repo.one()
+    |> case do
+      nil -> {:ok, 0}
+      results -> {:ok, results}
+    end
+  end
+
   @doc """
   Fetch a single objective by id
 

--- a/lib/cambiatus/sentry_error.ex
+++ b/lib/cambiatus/sentry_error.ex
@@ -1,4 +1,6 @@
 defmodule Cambiatus.SentryError do
+  @moduledoc false
+
   def run(blueprint, _) do
     errors = blueprint.result.errors
     Sentry.Context.set_extra_context(%{errors: errors})

--- a/lib/cambiatus_web/resolvers/objectives.ex
+++ b/lib/cambiatus_web/resolvers/objectives.ex
@@ -105,7 +105,6 @@ defmodule CambiatusWeb.Resolvers.Objectives do
   end
 
   def get_claim_count(%Action{} = action, filter, _) do
-    # Objectives.get_claim_count(action, filter)
     Objectives.get_claim_count(action, filter)
   end
 

--- a/lib/cambiatus_web/resolvers/objectives.ex
+++ b/lib/cambiatus_web/resolvers/objectives.ex
@@ -5,7 +5,7 @@ defmodule CambiatusWeb.Resolvers.Objectives do
   alias Absinthe.Relay.Connection
   alias Cambiatus.Commune.Community
   alias Cambiatus.Objectives
-  alias Cambiatus.Objectives.Claim
+  alias Cambiatus.Objectives.{Action, Claim}
 
   @doc """
   Fetches a claim
@@ -102,6 +102,11 @@ defmodule CambiatusWeb.Resolvers.Objectives do
 
   def get_claim_count(%Community{} = community, _, _) do
     Objectives.get_claim_count(community)
+  end
+
+  def get_claim_count(%Action{} = action, filter, _) do
+    # Objectives.get_claim_count(action, filter)
+    Objectives.get_claim_count(action, filter)
   end
 
   @spec complete_objective(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}

--- a/lib/cambiatus_web/schema/objective_types.ex
+++ b/lib/cambiatus_web/schema/objective_types.ex
@@ -24,7 +24,7 @@ defmodule CambiatusWeb.Schema.ObjectiveTypes do
     field :objective, :objective do
       arg(:id, non_null(:integer))
 
-      middleware(Middleware.Authenticate)
+      # middleware(Middleware.Authenticate)
       resolve(&Objectives.get_objective/3)
     end
   end
@@ -111,6 +111,11 @@ defmodule CambiatusWeb.Schema.ObjectiveTypes do
     field(:created_tx, non_null(:string))
     field(:created_eos_account, non_null(:string))
     field(:created_at, non_null(:datetime))
+
+    field(:claim_count, non_null(:integer)) do
+      arg(:status, :claim_status)
+      resolve(&Objectives.get_claim_count/3)
+    end
   end
 
   @desc "A claim made in an action"

--- a/lib/cambiatus_web/schema/objective_types.ex
+++ b/lib/cambiatus_web/schema/objective_types.ex
@@ -24,7 +24,7 @@ defmodule CambiatusWeb.Schema.ObjectiveTypes do
     field :objective, :objective do
       arg(:id, non_null(:integer))
 
-      # middleware(Middleware.Authenticate)
+      middleware(Middleware.Authenticate)
       resolve(&Objectives.get_objective/3)
     end
   end

--- a/lib/cambiatus_web/schema/objective_types.ex
+++ b/lib/cambiatus_web/schema/objective_types.ex
@@ -116,6 +116,8 @@ defmodule CambiatusWeb.Schema.ObjectiveTypes do
       arg(:status, :claim_status)
       resolve(&Objectives.get_claim_count/3)
     end
+
+    field(:image, :string)
   end
 
   @desc "A claim made in an action"

--- a/priv/repo/migrations/20220306210143_add_email_to_contact_type.exs
+++ b/priv/repo/migrations/20220306210143_add_email_to_contact_type.exs
@@ -1,5 +1,6 @@
 defmodule Cambiatus.Repo.Migrations.AddEmailToContactType do
   use Ecto.Migration
+  @disable_ddl_transaction true
 
   def up do
     execute("ALTER TYPE contact_type ADD VALUE 'email'")

--- a/priv/repo/migrations/20220307130343_add_link_to_contact_type.exs
+++ b/priv/repo/migrations/20220307130343_add_link_to_contact_type.exs
@@ -1,5 +1,6 @@
 defmodule Cambiatus.Repo.Migrations.AddLinkToContactType do
   use Ecto.Migration
+  @disable_ddl_transaction true
 
   def up do
     execute("ALTER TYPE contact_type ADD VALUE 'link'")


### PR DESCRIPTION
## What issue does this PR close
Closes #215 

## Changes Proposed ( a list of new changes introduced by this PR)
- Adds a new field `claimCount` to the `action` object.
- This new field gives an easy count of all claims that action has
- It provides an optional `status` filter that allow to filter down the number to only the selected status.

## How to test ( a list of instructions on how to test this PR)
- mix test


