### PR TITLE
Moved community description to optional fields

### DIFF
--- a/lib/cambiatus/commune/community.ex
+++ b/lib/cambiatus/commune/community.ex
@@ -80,8 +80,8 @@ defmodule Cambiatus.Commune.Community do
     )
   end
 
-  @required_fields ~w(symbol creator name description inviter_reward invited_reward has_news)a
-  @optional_fields ~w(logo type supply max_supply min_balance issuer subdomain_id website
+  @required_fields ~w(symbol creator name inviter_reward invited_reward has_news)a
+  @optional_fields ~w(description logo type supply max_supply min_balance issuer subdomain_id website
    created_block created_tx created_at created_eos_account highlighted_news_id)a
 
   @doc false

--- a/test/cambiatus/commune/community_test.exs
+++ b/test/cambiatus/commune/community_test.exs
@@ -5,13 +5,39 @@ defmodule Cambiatus.Commune.CommunityTest do
   use Cambiatus.DataCase
 
   alias Cambiatus.{
-    Commune
+    Commune,
+    Commune.Community
   }
 
   describe "Community Changeset " do
     test "change_community/1 returns a community changeset" do
       community = insert(:community)
       assert %Ecto.Changeset{} = Commune.change_community(community)
+    end
+
+    test "create a valid community changeset with empty values" do
+      params = %{
+        description: "",
+        logo: "",
+        type: "",
+        supply: nil,
+        max_supply: nil,
+        min_balance: nil,
+        issuer: "",
+        website: "",
+        auto_invite: nil,
+        has_objectives: nil,
+        has_shop: nil,
+        has_kyc: nil,
+        highlighted_news: nil
+      }
+
+      changeset =
+        build(:community, params)
+        |> Community.changeset(%{})
+
+      assert true == changeset.valid?
+      assert [] == changeset.errors
     end
   end
 end


### PR DESCRIPTION
## What issue does this PR close
Closes #230 

## Changes Proposed ( a list of new changes introduced by this PR)
- [x] Accept empty description on community changesets
- [x] Test valid changeset for a community with `""` as description


## How to test ( a list of instructions on how to test this PR)
Run `mix test test/Cambiatus/Commune/community_test.exs`


