### PR TITLE
Cleanup unnecessary metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -45,6 +45,12 @@ config :sentry,
   enable_source_code_context: true,
   root_source_code_path: File.cwd!()
 
+config :mogrify,
+  strip_command: [
+    path: "magick",
+    args: ["strip"]
+  ]
+
 config :cambiatus, Oban,
   repo: Cambiatus.Repo,
   queues: [

--- a/lib/cambiatus/file/uploader.ex
+++ b/lib/cambiatus/file/uploader.ex
@@ -53,8 +53,11 @@ defmodule Cambiatus.File.Uploader do
     image_path
     |> Mogrify.open()
     |> Mogrify.resize_to_limit(~s(#{width}x#{height}))
+    |> strip_metadata()
     |> Mogrify.save(opts)
   end
+
+  def strip_metadata(image), do: Mogrify.custom(image, "strip")
 
   @doc """
   Saves a file


### PR DESCRIPTION
## What issue does this PR close
Closes #214 

## Changes Proposed ( a list of new changes introduced by this PR)

- [ ] Cleanup unnecessary metada from image uploads
- [ ] Leave important metada for image display


## How to test ( a list of instructions on how to test this PR)
Run the function `Cambiatus.File.Uploader.strip_metadata(%{image_path})` on an image to strip the metada and check the results



