### PR TITLE
Script para atualização de campos com string vazia

### DIFF
--- a/priv/repo/migrations/20220808193453_no_empty_string_constraint.exs
+++ b/priv/repo/migrations/20220808193453_no_empty_string_constraint.exs
@@ -1,0 +1,37 @@
+defmodule Cambiatus.Repo.Migrations.NoEmptyStringConstraint do
+  use Ecto.Migration
+
+  def change do
+    create(constraint("actions", :no_empty_string_on_actions_images, check: "image <> ''"))
+
+    create(
+      constraint("actions", :no_empty_string_on_actions_photo_proof_instructions,
+        check: "photo_proof_instructions <> ''"
+      )
+    )
+
+    create(
+      constraint("claims", :no_empty_string_on_claims_proof_photo, check: "proof_photo <> ''")
+    )
+
+    create(constraint("claims", :no_empty_string_on_claims_proof_code, check: "proof_code <> ''"))
+
+    create(constraint("communities", :no_empty_string_on_communities_logo, check: "logo <> ''"))
+
+    create(
+      constraint("communities", :no_empty_string_on_communities_description,
+        check: "description <> ''"
+      )
+    )
+
+    create(
+      constraint("communities", :no_empty_string_on_communities_website, check: "website <> ''")
+    )
+
+    create(
+      constraint("products", :no_empty_string_on_products_description, check: "description <> ''")
+    )
+
+    create(constraint("transfers", :no_empty_string_on_transfers_memo, check: "memo <> ''"))
+  end
+end

--- a/priv/repo/migrations/20220808193453_no_empty_string_constraint.exs
+++ b/priv/repo/migrations/20220808193453_no_empty_string_constraint.exs
@@ -1,6 +1,18 @@
 defmodule Cambiatus.Repo.Migrations.NoEmptyStringConstraint do
   use Ecto.Migration
 
+  # This migration adds checks to prevent that empty strings are written into the db
+  # The fields affected are
+  #   Objectives.Action.photo_proof_instructions
+  #   Objectives.Action.image
+  #   Objectives.Claim.proof_photo
+  #   Objectives.Claim.proof_code
+  #   Commune.Community.logo
+  #   Commune.Community.description
+  #   Commune.Community.website
+  #   Commune.Transfer.memo
+  #   Shop.Product.description
+
   def change do
     create(constraint("actions", :no_empty_string_on_actions_images, check: "image <> ''"))
 

--- a/priv/repo/null_strings.exs
+++ b/priv/repo/null_strings.exs
@@ -1,0 +1,26 @@
+IO.puts("Replacing empty strings with null")
+
+import Ecto.Query
+
+alias Cambiatus.Repo
+alias Cambiatus.Objectives.{Action, Claim}
+
+fields = %{Action => [:image], Claim => [:proof_photo, :proof_code]}
+
+Enum.each(Map.keys(fields), fn schema ->
+  fields
+  |> Map.get(schema)
+  |> Enum.each(fn field ->
+    schema
+    |> where([s], field(s, ^field) == "")
+    |> update([s], set: [{^field, nil}])
+    |> Repo.update_all([])
+    |> case do
+      {0, nil} ->
+        IO.puts("No values were changed for #{schema}.#{field}")
+
+      {changes_num, _} ->
+        IO.puts("#{changes_num} changes were made to #{schema}.#{field}")
+    end
+  end)
+end)

--- a/priv/repo/null_strings.exs
+++ b/priv/repo/null_strings.exs
@@ -4,8 +4,16 @@ import Ecto.Query
 
 alias Cambiatus.Repo
 alias Cambiatus.Objectives.{Action, Claim}
+alias Cambiatus.Commune.{Community, Transfer}
+alias Cambiatus.Shop.Product
 
-fields = %{Action => [:image], Claim => [:proof_photo, :proof_code]}
+fields = %{
+  Action => [:photo_proof_instructions, :image],
+  Claim => [:proof_photo, :proof_code],
+  Community => [:logo, :description, :website],
+  Product => [:description],
+  Transfer => [:memo]
+}
 
 Enum.each(Map.keys(fields), fn schema ->
   fields

--- a/priv/repo/replace_empty_strings_ingested_with_nil.exs
+++ b/priv/repo/replace_empty_strings_ingested_with_nil.exs
@@ -1,4 +1,17 @@
-IO.puts("Replacing empty strings with null")
+IO.puts("""
+Replace the following empty string ingested by the event-source with nil:
+  Objectives.Action.photo_proof_instructions
+  Objectives.Action.image
+  Objectives.Claim.proof_photo
+  Objectives.Claim.proof_code
+  Commune.Community.logo
+  Commune.Community.description
+  Commune.Community.website
+  Commune.Transfer.memo
+  Shop.Product.description
+
+""")
+
 
 import Ecto.Query
 
@@ -14,6 +27,10 @@ fields = %{
   Product => [:description],
   Transfer => [:memo]
 }
+
+# Iterate over the schemas defined as the keys in the field map
+# Then iterate over the fields defined as the values in the fields map
+# And for each field find entries with empty strings and update them as nil
 
 Enum.each(Map.keys(fields), fn schema ->
   fields


### PR DESCRIPTION
## What issue does this PR close
Closes #266 

## Changes Proposed ( a list of new changes introduced by this PR)
Criar script para detectar valores `""` já existentes na db e atualizá-los para `nil`

## How to test ( a list of instructions on how to test this PR)
1. Procurar na db por valores com `''`
2. Executar `iex -S mix priv/repo/null_string.exs`
3. Verficar se os valores foram alterados para `NULL`
