### PR TITLE
Fix two wrong instances of product_category mutations

### DIFF
--- a/lib/cambiatus/shop.ex
+++ b/lib/cambiatus/shop.ex
@@ -48,7 +48,16 @@ defmodule Cambiatus.Shop do
     end
   end
 
-  def create_product(attrs \\ %{}) do
+  def create_product(%{categories: categories} = attrs) do
+    attrs =
+      attrs
+      |> Map.merge(%{product_categories: Enum.map(categories, &%{category_id: &1})})
+      |> Map.delete(:categories)
+
+    create_product(attrs)
+  end
+
+  def create_product(attrs) do
     %Product{}
     |> Product.changeset(attrs, :create)
     |> Repo.insert()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,4 @@
-# 5 minutes
-ExUnit.start(timeout: 5 * 60_000, exclude: [:skip])
+ExUnit.start(timeout: 5 * 60_000, exclude: [:skip], capture_log: true)
 
 # Set the pool mode to manual for explicitly checkouts
 Ecto.Adapters.SQL.Sandbox.mode(Cambiatus.Repo, :manual)


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)

- Adjust the way we relate product and product categories
- Add extra info (community_id and creator_id) to product when creating
- Make sure we can create new products with categories related
- Make sure we can change categories of an existing product that already had categories 

## How to test ( a list of instructions on how to test this PR)
- `mix test`


