### PR TITLE
Fix/product category fixes

### DIFF
--- a/lib/cambiatus/shop.ex
+++ b/lib/cambiatus/shop.ex
@@ -270,6 +270,7 @@ defmodule Cambiatus.Shop do
         # Get all root categories that have position bigger or equal than
         transaction =
           Category
+          |> Category.from_community(attrs.community_id)
           |> Category.roots()
           |> Category.position_bigger_equals_then(position)
           |> Repo.all()

--- a/lib/cambiatus/shop.ex
+++ b/lib/cambiatus/shop.ex
@@ -290,7 +290,8 @@ defmodule Cambiatus.Shop do
           {:error, :category, error, _} ->
             {:error, error}
 
-          _error ->
+          error ->
+            Sentry.capture_message("Category creation failed", extra: %{error: error})
             {:error, "Can't create new category"}
         end
 

--- a/lib/cambiatus/shop.ex
+++ b/lib/cambiatus/shop.ex
@@ -9,7 +9,7 @@ defmodule Cambiatus.Shop do
 
   alias Cambiatus.Commune
   alias Cambiatus.Repo
-  alias Cambiatus.Shop.{Category, Product, Order}
+  alias Cambiatus.Shop.{Category, Product, ProductCategory, Order}
 
   @spec data(any) :: Dataloader.Ecto.t()
   def data(params \\ %{}) do
@@ -429,4 +429,6 @@ defmodule Cambiatus.Shop do
   def change_category(%Category{} = category, attrs \\ %{}) do
     Category.changeset(category, attrs)
   end
+
+  def get_product_category!(id), do: Repo.get!(ProductCategory, id)
 end

--- a/lib/cambiatus/shop/category.ex
+++ b/lib/cambiatus/shop/category.ex
@@ -39,7 +39,7 @@ defmodule Cambiatus.Shop.Category do
       on_replace: :nilify
     )
 
-    many_to_many(:products, Product, join_through: ProductCategory)
+    many_to_many(:products, Product, join_through: ProductCategory, on_delete: :delete_all)
   end
 
   @required_fields ~w(community_id name description slug position)a

--- a/test/cambiatus/shop_test.exs
+++ b/test/cambiatus/shop_test.exs
@@ -163,6 +163,20 @@ defmodule Cambiatus.ShopTest do
       assert_raise Ecto.NoResultsError, fn -> Shop.get_category!(grandchild.id) end
     end
 
+    test "delete_category/1 deletes category and product_category associations" do
+      admin = insert(:user)
+      community = insert(:community, creator: admin.account)
+      category = insert(:category, community: community)
+      product = insert(:product, community: community)
+      product_category = insert(:product_category, product: product, category: category)
+
+      assert {:ok, "Category deleted successfully"} =
+               Shop.delete_category(category.id, admin, community.symbol)
+
+      assert_raise Ecto.NoResultsError, fn -> Shop.get_category!(category.id) end
+      assert_raise Ecto.NoResultsError, fn -> Shop.get_product_category!(product_category.id) end
+    end
+
     test "change_category/1 returns a category changeset", %{community: community} do
       category = insert(:category, community_id: community.symbol)
       assert %Ecto.Changeset{} = Shop.change_category(category)

--- a/test/cambiatus_web/schema/resolvers/shop_test.exs
+++ b/test/cambiatus_web/schema/resolvers/shop_test.exs
@@ -742,7 +742,7 @@ defmodule CambiatusWeb.Resolvers.ShopTest do
                    "imageUri" => nil,
                    "position" => 0,
                    "iconUri" => nil,
-                   "metaTitle" => nil,
+                   "metaTitle" => nil
                  }
                }
              } == response

--- a/test/cambiatus_web/schema/resolvers/shop_test.exs
+++ b/test/cambiatus_web/schema/resolvers/shop_test.exs
@@ -700,6 +700,54 @@ defmodule CambiatusWeb.Resolvers.ShopTest do
              } == response
     end
 
+    test "create new with full params" do
+      user = insert(:user)
+      community = insert(:community, creator: user.account)
+
+      conn = auth_conn(user, community.subdomain.name)
+
+      mutation = """
+        mutation {
+          category(description: "the first one!",
+                    name: "First category :)",
+                    position: 0,
+                    slug: "first-category") {
+            slug
+            name
+            position
+            metaKeywords
+            metaDescription
+            metaTitle
+            parent { id: id }
+            imageUri
+            iconUri
+            description
+          }
+        }
+      """
+
+      res = post(conn, "/api/graph", query: mutation)
+
+      response = json_response(res, 200)
+
+      assert %{
+               "data" => %{
+                 "category" => %{
+                   "name" => "First category :)",
+                   "description" => "the first one!",
+                   "slug" => "first-category",
+                   "parent" => nil,
+                   "metaKeywords" => nil,
+                   "metaDescription" => nil,
+                   "imageUri" => nil,
+                   "position" => 0,
+                   "iconUri" => nil,
+                   "metaTitle" => nil,
+                 }
+               }
+             } == response
+    end
+
     test "add existing categories as subcategories to a new category", %{
       conn: conn,
       community: community


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
- Fixes error that would be raised when we try to delete a category already associated with a product. Now it deletes the association with the product.

## How to test ( a list of instructions on how to test this PR)
run `mix test` there are test cases for those bugs

