### PR TITLE
Fix/unsubscribe page visual bugs

### DIFF
--- a/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
+++ b/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
@@ -251,7 +251,7 @@
                     <li class="row">
                         <div class="flexing">
                             <span>
-                                <%= gettext("Transfer Notification") %>
+                                <%= gettext("Transfer notification") %>
                             </span>
                             <div class="flexing">
                                 <label for="transfers" class="switch-label"></label>

--- a/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
+++ b/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
@@ -187,7 +187,6 @@
                 }
 
                 .alert {
-                    width: 100%;
                     margin-bottom: 50px;
                     padding: 10px;
                     position: -webkit-sticky;

--- a/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
+++ b/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
@@ -85,17 +85,11 @@
 
                 .row {
                     width: 100%;
-                    height: 60px;
-                    line-height: 60px;
+                    line-height: 15px;
+                    padding-top: 16px;
+                    padding-bottom: 16px;
                     border-bottom: 1px solid #E7E7E7;
                 }
-
-                .bottom-row {
-                    width: 100%;
-                    height: 60px;
-                    line-height: 60px;
-                }
-
 
                 .ul {
                     list-style-type: none;
@@ -263,7 +257,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="bottom-row">
+                    <li class="row" style="border-bottom: 0px; padding-bottom: 0px;">
                         <div class="flexing">
                             <span>
                                 <%= gettext("Monthly news about the community") %>

--- a/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
+++ b/lib/cambiatus_web/templates/unsubscribe/email_unsubscribe.html.eex
@@ -87,6 +87,9 @@
                     width: 100%;
                     line-height: 15px;
                     padding-top: 16px;
+                }
+
+                .row:not(:last-of-type) {
                     padding-bottom: 16px;
                     border-bottom: 1px solid #E7E7E7;
                 }
@@ -257,7 +260,7 @@
                             </div>
                         </div>
                     </li>
-                    <li class="row" style="border-bottom: 0px; padding-bottom: 0px;">
+                    <li class="row">
                         <div class="flexing">
                             <span>
                                 <%= gettext("Monthly news about the community") %>


### PR DESCRIPTION
## What issue does this PR close
Closes #289 

## Changes Proposed ( a list of new changes introduced by this PR)
Fix visual bugs on email unsubscribe page

## How to test ( a list of instructions on how to test this PR)
Check the email unsubscribe page by clicking on the unsubscribe link on an email. This will only work in the staging environment. Since #276 emails are not being sent on staging so it's necessary to manually send the emails connecting to the staging server via SSH.

Alternatively, [click here](https://inex.staging.cambiatus.io/mailer/unsubscribe?token=SFMyNTY.g2gDdAAAAAFkAAJpZG0AAAAMbWF0aGV1c3Rlc3QzbgYAgxNX0YIBYgABUYA.pXVyqU_HIo932qBY3bZyDmHpotv-8ucAfSDzcXM7wY0) to go to the page with one of my accounts.
