### PR TITLE
Fix/fix monthly digest workers

### DIFF
--- a/lib/cambiatus/accounts.ex
+++ b/lib/cambiatus/accounts.ex
@@ -105,7 +105,16 @@ defmodule Cambiatus.Accounts do
 
   """
   def get_user!(id), do: Repo.get!(User, id)
-  def get_user(id), do: Repo.get(User, id)
+
+  def get_user(id) do
+    case Repo.get(User, id) do
+      nil ->
+        {:error, "No user with account: #{id} found"}
+
+      val ->
+        {:ok, val}
+    end
+  end
 
   @doc """
   Returns the number of analysis the user already did

--- a/lib/cambiatus/auth.ex
+++ b/lib/cambiatus/auth.ex
@@ -167,10 +167,10 @@ defmodule Cambiatus.Auth do
     account
     |> Accounts.get_user()
     |> case do
-      nil ->
-        {:error, "Could not find user"}
+      {:error, reason} ->
+        {:error, reason}
 
-      user ->
+      {:ok, user} ->
         params = %{
           user_id: user.account,
           phrase: :crypto.strong_rand_bytes(64) |> Base.encode64() |> binary_part(0, 64),

--- a/lib/cambiatus/auth/sign_up.ex
+++ b/lib/cambiatus/auth/sign_up.ex
@@ -34,7 +34,7 @@ defmodule Cambiatus.Auth.SignUp do
         error
 
       _result ->
-        {:ok, Accounts.get_user(params.account)}
+        {:ok, Accounts.get_user!(params.account)}
     end
   end
 
@@ -72,10 +72,10 @@ defmodule Cambiatus.Auth.SignUp do
           map() | {:error, any()}
   def validate(%{account: account} = params, :account) do
     case Accounts.get_user(account) do
-      nil ->
+      {:error, _} ->
         params
 
-      %User{} ->
+      {:ok, %User{}} ->
         {:error, :user_already_registred}
     end
   end

--- a/lib/cambiatus/workers/digest_email_worker.ex
+++ b/lib/cambiatus/workers/digest_email_worker.ex
@@ -1,0 +1,22 @@
+defmodule Cambiatus.Workers.DigestEmailWorker do
+  @moduledoc """
+  Handles sending news digest email
+  """
+  use Oban.Worker,
+    queue: :mailers,
+    max_attempts: 3,
+    tags: ["digest"],
+    unique: [period: 120]
+
+  alias Cambiatus.{Accounts, Commune}
+
+  def perform(%Oban.Job{args: %{"community_id" => community_id, "account" => account}}) do
+    with {:ok, community} <- Commune.get_community(community_id),
+         {:ok, member} <- Accounts.get_user(account) do
+      CambiatusWeb.Email.monthly_digest(community, member)
+    else
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/cambiatus/workers/monthly_digest_worker.ex
+++ b/lib/cambiatus/workers/monthly_digest_worker.ex
@@ -12,8 +12,6 @@ defmodule Cambiatus.Workers.MonthlyDigestWorker do
   alias Ecto.Multi
 
   def perform(_) do
-    multi = Multi.new()
-
     transaction =
       Community
       |> Community.with_news_enabled()
@@ -24,7 +22,7 @@ defmodule Cambiatus.Workers.MonthlyDigestWorker do
         :subdomain
       ])
       |> Enum.filter(&Enum.any?(&1.news))
-      |> Enum.reduce(multi, fn community, multi ->
+      |> Enum.reduce(Multi.new(), fn community, multi ->
         Enum.reduce(community.members, multi, fn member, multi ->
           Oban.insert(
             multi,

--- a/lib/cambiatus_web/channels/user_socket.ex
+++ b/lib/cambiatus_web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule CambiatusWeb.UserSocket do
   use Absinthe.Phoenix.Socket, schema: CambiatusWeb.Schema
 
   alias CambiatusWeb.AuthToken
+  alias Cambiatus.Accounts.User
 
   ## Channels
   # channel "room:*", EatYourDayWeb.RoomChannel
@@ -30,7 +31,7 @@ defmodule CambiatusWeb.UserSocket do
   defp build_context(%{"Authorization" => "Bearer " <> token} = params, context) do
     context =
       with {:ok, %{id: account}} <- AuthToken.verify(token),
-           %Cambiatus.Accounts.User{} = user <- Cambiatus.Accounts.get_user(account) do
+           {:ok, %User{} = user} <- Cambiatus.Accounts.get_user(account) do
         Map.put(context, :current_user, user)
       else
         _ -> context

--- a/lib/cambiatus_web/controllers/unsubscribe_controller.ex
+++ b/lib/cambiatus_web/controllers/unsubscribe_controller.ex
@@ -44,7 +44,7 @@ defmodule CambiatusWeb.UnsubscribeController do
 
   def get_current_user(token) do
     with {:ok, %{id: account}} <- AuthToken.verify(token, "email"),
-         %Accounts.User{} = current_user <- Accounts.get_user(account) do
+         {:ok, %Accounts.User{} = current_user} <- Accounts.get_user(account) do
       {:ok, current_user}
     else
       _ ->

--- a/lib/cambiatus_web/email.ex
+++ b/lib/cambiatus_web/email.ex
@@ -11,6 +11,7 @@ defmodule CambiatusWeb.Email do
   alias Cambiatus.Commune.{Community, Transfer}
   alias Cambiatus.Accounts.User
   alias Cambiatus.Objectives.Claim
+  alias Cambiatus.Social.News
 
   def welcome(user) do
     new(
@@ -41,8 +42,11 @@ defmodule CambiatusWeb.Email do
     |> Mailer.deliver()
   end
 
-  # input is a community with preloaded news with less than 30 days and members with active digest
-  def monthly_digest(community, member) do
+  # input is a community and a user
+  # community and memebr filtering is done by the MonthlyDigestWorker
+  def monthly_digest(%Community{} = community, %User{} = member) do
+    community = Repo.preload(community, [:subdomain, [news: News.last_thirty_days()]])
+
     compose_email_headers(member, community)
     |> subject("#{community.name} - " <> gettext("Community News"))
     |> render_body("monthly_digest.html", render_params(member, community))

--- a/lib/cambiatus_web/email.ex
+++ b/lib/cambiatus_web/email.ex
@@ -42,13 +42,11 @@ defmodule CambiatusWeb.Email do
   end
 
   # input is a community with preloaded news with less than 30 days and members with active digest
-  def monthly_digest(community) do
-    Enum.each(community.members, fn member ->
-      compose_email_headers(member, community)
-      |> subject("#{community.name} - " <> gettext("Community News"))
-      |> render_body("monthly_digest.html", render_params(member, community))
-      |> Mailer.deliver()
-    end)
+  def monthly_digest(community, member) do
+    compose_email_headers(member, community)
+    |> subject("#{community.name} - " <> gettext("Community News"))
+    |> render_body("monthly_digest.html", render_params(member, community))
+    |> Mailer.deliver()
   end
 
   def compose_email_headers(recipient, community) do

--- a/lib/cambiatus_web/email.ex
+++ b/lib/cambiatus_web/email.ex
@@ -43,7 +43,7 @@ defmodule CambiatusWeb.Email do
   end
 
   # input is a community and a user
-  # community and memebr filtering is done by the MonthlyDigestWorker
+  # community and member filtering is done by the MonthlyDigestWorker
   def monthly_digest(%Community{} = community, %User{} = member) do
     community = Repo.preload(community, [:subdomain, [news: News.last_thirty_days()]])
 

--- a/lib/cambiatus_web/plugs/set_current_user.ex
+++ b/lib/cambiatus_web/plugs/set_current_user.ex
@@ -10,6 +10,7 @@ defmodule CambiatusWeb.Plugs.SetCurrentUser do
   import Plug.Conn
 
   alias CambiatusWeb.AuthToken
+  alias Cambiatus.Accounts.User
 
   def init(opts), do: opts
 
@@ -25,13 +26,13 @@ defmodule CambiatusWeb.Plugs.SetCurrentUser do
   def set_current_user(conn) do
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
          {:ok, %{id: account}} <- AuthToken.verify(token),
-         %{} = user <- Cambiatus.Accounts.get_user(account) do
+         {:ok, %User{} = user} <- Cambiatus.Accounts.get_user(account) do
       %{current_user: user}
     else
       _ ->
         with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
              {:ok, %{id: account}} <- AuthToken.verify(token, "email"),
-             %{} = user <- Cambiatus.Accounts.get_user(account) do
+             {:ok, %User{} = user} <- Cambiatus.Accounts.get_user(account) do
           %{user_unsub_email: user}
         else
           _ ->

--- a/test/cambiatus/auth/sign_in_test.exs
+++ b/test/cambiatus/auth/sign_in_test.exs
@@ -25,7 +25,7 @@ defmodule Cambiatus.Auth.SignInTest do
 
     test "non existing user sign_in", %{community: community} do
       assert SignIn.sign_in("nonexisting", "", community: community) ==
-               {:error, "Account not found"}
+               {:error, "No user with account: nonexisting found"}
     end
 
     test "sign in with invitation" do

--- a/test/cambiatus/shop/product_test.exs
+++ b/test/cambiatus/shop/product_test.exs
@@ -34,7 +34,7 @@ defmodule Cambiatus.Shop.ProductTest do
     test "deletes product" do
       user = insert(:user)
       product = insert(:product, %{creator: user})
-      user = Cambiatus.Accounts.get_user(product.creator_id)
+      user = Cambiatus.Accounts.get_user!(product.creator_id)
 
       assert Shop.get_product(product.id)
 

--- a/test/cambiatus/social_test.exs
+++ b/test/cambiatus/social_test.exs
@@ -291,7 +291,7 @@ defmodule Cambiatus.SocialTest do
       community = insert(:community, has_news: true, creator: user.account)
       news = insert(:news, community: community, user: user)
 
-      user = Cambiatus.Accounts.get_user(news.user_id)
+      user = Cambiatus.Accounts.get_user!(news.user_id)
 
       assert Social.get_news(news.id)
 

--- a/test/cambiatus/workers/digest_email_worker_test.exs
+++ b/test/cambiatus/workers/digest_email_worker_test.exs
@@ -1,0 +1,89 @@
+defmodule Cambiatus.Workers.DigestEmailWorkerTest do
+  use Cambiatus.DataCase
+  use Oban.Testing, repo: Cambiatus.Repo
+
+  alias Cambiatus.Workers.DigestEmailWorker
+
+  import Swoosh.TestAssertions
+
+  describe "perform/1" do
+    test "sends email to user" do
+      user = insert(:user)
+      community = insert(:community)
+
+      assert {:ok, _} =
+               perform_job(DigestEmailWorker, %{
+                 "community_id" => community.symbol,
+                 "account" => user.account
+               })
+
+      {:messages, messages} = :erlang.process_info(self(), :messages)
+
+      user_token =
+        messages[:email]
+        |> Map.get(:headers)
+        |> Map.get("List-Unsubscribe")
+        |> String.split("token=")
+        |> List.last()
+        |> String.replace(">", "")
+
+      assert_email_sent(
+        to: user.email,
+        from: {"#{community.name} - Cambiatus", "no-reply@cambiatus.com"},
+        subject: "#{community.name} - Community News",
+        headers: %{
+          "List-Unsubscribe" =>
+            "<https://#{community.subdomain.name}/api/unsubscribe?token=#{user_token}>",
+          "List-Unsubscribe-Post" => "List-Unsubscribe=One-Click"
+        }
+      )
+
+      refute_email_sent()
+    end
+
+    test "will only this month news" do
+      user = insert(:user)
+      community = insert(:community)
+
+      # News created last week
+      news1 =
+        insert(:news,
+          community: community,
+          title: "First news",
+          updated_at: DateTime.utc_now() |> DateTime.add(-3600 * 24 * 7, :second)
+        )
+
+      # News created this month
+      news2 =
+        insert(:news,
+          community: community,
+          title: "Second news",
+          updated_at: DateTime.utc_now() |> DateTime.add(-3600 * 24 * 28, :second)
+        )
+
+      # News created last month
+      news3 =
+        insert(:news,
+          community: community,
+          title: "Third news",
+          updated_at: DateTime.utc_now() |> DateTime.add(-3600 * 24 * 32, :second)
+        )
+
+      assert {:ok, _} =
+               perform_job(DigestEmailWorker, %{
+                 "community_id" => community.symbol,
+                 "account" => user.account
+               })
+
+      {:messages, messages} = :erlang.process_info(self(), :messages)
+
+      body = messages[:email] |> Map.get(:html_body)
+
+      assert_email_sent(to: user.email)
+
+      assert String.contains?(body, news1.title)
+      assert String.contains?(body, news2.title)
+      refute String.contains?(body, news3.title)
+    end
+  end
+end

--- a/test/cambiatus/workers/monthly_digest_worker_test.exs
+++ b/test/cambiatus/workers/monthly_digest_worker_test.exs
@@ -104,8 +104,8 @@ defmodule Cambiatus.Workers.MonthlyDigestWorkerTest do
 
     test "emails won't be sent if community does not have news in last 30 days" do
       community = insert(:community, has_news: true)
-
       user = insert(:user)
+      insert(:network, user: user, community: community)
 
       insert(:news,
         community: community,
@@ -116,9 +116,6 @@ defmodule Cambiatus.Workers.MonthlyDigestWorkerTest do
         community: community,
         updated_at: DateTime.utc_now() |> DateTime.add(-3600 * 24 * 40, :second)
       )
-
-      user = insert(:user)
-      insert(:network, user: user, community: community)
 
       assert {:ok, _} = perform_job(MonthlyDigestWorker, %{})
 

--- a/test/cambiatus_web/email_test.exs
+++ b/test/cambiatus_web/email_test.exs
@@ -75,7 +75,7 @@ defmodule CambiatusWeb.EmailTest do
 
     community
     |> Repo.preload([:members, :news])
-    |> CambiatusWeb.Email.monthly_digest()
+    |> CambiatusWeb.Email.monthly_digest(user)
 
     {:messages, messages} = :erlang.process_info(self(), :messages)
 


### PR DESCRIPTION
## What issue does this PR close
Closes #294 

## Changes Proposed ( a list of new changes introduced by this PR)
Refactor Monthly Digest Worker to make it so that an individual worker is responsible for an individual user, instead of a single worker being responsible for the entire community.

## How to test ( a list of instructions on how to test this PR)
Run `mix test`


