### PR TITLE
Give errors to Oban as 2 tuples

### DIFF
--- a/lib/cambiatus/workers/contribution_paypal_worker.ex
+++ b/lib/cambiatus/workers/contribution_paypal_worker.ex
@@ -24,7 +24,7 @@ defmodule Cambiatus.Workers.ContributionPaypalWorker do
       {:error, _} = error ->
         error
 
-      {:error, _, %{valid?: false}} ->
+      {:error, _, %{valid?: false}, _} ->
         {:error, :invalid_changeset}
     end
   end


### PR DESCRIPTION
## Please note
This is a subset of cambiatus/backend#306

## What issue does this PR close
Closes cambiatus/backend#304

## Changes Proposed ( a list of new changes introduced by this PR)
Return 2 tuple errors to Oban. 4 tuple errors are generated when `Multi.new` is upstream of `Repo.transaction`.

## How to test ( a list of instructions on how to test this PR)
Existing unit test coverage. They passed for me locally, after running `mix format` and `mix credo`.

## Please note
I am submitting two versions of this change. This PR addresses the error handling. The next PR will have that, and it will include the credo check.